### PR TITLE
SpeechToTextService made more developer friendly

### DIFF
--- a/src/IBM.WatsonDeveloperCloud.SpeechToText/v1/ISpeechToTextService.cs
+++ b/src/IBM.WatsonDeveloperCloud.SpeechToText/v1/ISpeechToTextService.cs
@@ -95,20 +95,20 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
         /// <returns></returns>
         SpeechRecognitionEvent Recognize(string contentType,
                                          FileStream audio,
-                                         string transferEncoding,
-                                         string model,
-                                         string customizationId,
-                                         bool? continuous,
-                                         int? inactivityTimeout,
-                                         string[] keywords,
-                                         double? keywordsThreshold,
-                                         int? maxAlternatives,
-                                         double? wordAlternativesThreshold,
-                                         bool? wordConfidence,
-                                         bool? timestamps,
-                                         bool profanityFilter,
-                                         bool? smartFormatting,
-                                         bool? speakerLabels);
+                                         string transferEncoding = "",
+                                         string model = "en-US_BroadbandModel",
+                                         string customizationId = "",
+                                         bool? continuous = null,
+                                         int? inactivityTimeout = null,
+                                         string[] keywords = null,
+                                         double? keywordsThreshold = null,
+                                         int? maxAlternatives = null,
+                                         double? wordAlternativesThreshold = null,
+                                         bool? wordConfidence = null,
+                                         bool? timestamps = null,
+                                         bool profanityFilter = false,
+                                         bool? smartFormatting = null,
+                                         bool? speakerLabels = null);
 
         /// <summary>
         /// Sends audio and returns transcription results for a sessionless recognition request. Returns only the final results; to enable interim results, use Sessions or WebSockets. The service imposes a data size limit of 100 MB. It automatically detects the endianness of the incoming audio and, for audio that includes multiple channels, downmixes the audio to one-channel mono during transcoding.
@@ -125,9 +125,9 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
         SpeechRecognitionEvent Recognize(string contentType,
                                          Metadata metaData,
                                          FileStream audio,
-                                         string transferEncoding,
-                                         string model,
-                                         string customizationId);
+                                          string transferEncoding = "",
+                                          string model = "en-US_BroadbandModel",
+                                          string customizationId = "");
 
         /// <summary>
         /// Sends audio and returns transcription results for a sessionless recognition request. Returns only the final results; to enable interim results, use Sessions or WebSockets. The service imposes a data size limit of 100 MB. It automatically detects the endianness of the incoming audio and, for audio that includes multiple channels, downmixes the audio to one-channel mono during transcoding.
@@ -155,20 +155,20 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
         SpeechRecognitionEvent RecognizeWithSession(string sessionId,
                                                     string contentType,
                                                     FileStream audio,
-                                                    string transferEncoding,
-                                                    string model,
-                                                    string customizationId,
-                                                    bool? continuous,
-                                                    int? inactivityTimeout,
-                                                    string[] keywords,
-                                                    double? keywordsThreshold,
-                                                    int? maxAlternatives,
-                                                    double? wordAlternativesThreshold,
-                                                    bool? wordConfidence,
-                                                    bool? timestamps,
-                                                    bool profanityFilter,
-                                                    bool? smartFormatting,
-                                                    bool? speakerLabels);
+                                                    string transferEncoding = "",
+                                                    string model = "en-US_BroadbandModel",
+                                                    string customizationId = "",
+                                                    bool? continuous = null,
+                                                    int? inactivityTimeout = null,
+                                                    string[] keywords = null,
+                                                    double? keywordsThreshold = null,
+                                                    int? maxAlternatives = null,
+                                                    double? wordAlternativesThreshold = null,
+                                                    bool? wordConfidence = null,
+                                                    bool? timestamps = null,
+                                                    bool profanityFilter = false,
+                                                    bool? smartFormatting = null,
+                                                    bool? speakerLabels = null);
 
         /// <summary>
         /// Sends audio and returns transcription results for a sessionless recognition request. Returns only the final results; to enable interim results, use Sessions or WebSockets. The service imposes a data size limit of 100 MB. It automatically detects the endianness of the incoming audio and, for audio that includes multiple channels, downmixes the audio to one-channel mono during transcoding.

--- a/src/IBM.WatsonDeveloperCloud.SpeechToText/v1/ISpeechToTextService.cs
+++ b/src/IBM.WatsonDeveloperCloud.SpeechToText/v1/ISpeechToTextService.cs
@@ -94,7 +94,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
         /// <param name="speakerLabels"></param>
         /// <returns></returns>
         SpeechRecognitionEvent Recognize(string contentType,
-                                         FileStream audio,
+                                         Stream audio,
                                          string transferEncoding = "",
                                          string model = "en-US_BroadbandModel",
                                          string customizationId = "",
@@ -124,10 +124,10 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
         /// <returns></returns>
         SpeechRecognitionEvent Recognize(string contentType,
                                          Metadata metaData,
-                                         FileStream audio,
-                                          string transferEncoding = "",
-                                          string model = "en-US_BroadbandModel",
-                                          string customizationId = "");
+                                         Stream audio,
+                                         string transferEncoding = "",
+                                         string model = "en-US_BroadbandModel",
+                                         string customizationId = "");
 
         /// <summary>
         /// Sends audio and returns transcription results for a sessionless recognition request. Returns only the final results; to enable interim results, use Sessions or WebSockets. The service imposes a data size limit of 100 MB. It automatically detects the endianness of the incoming audio and, for audio that includes multiple channels, downmixes the audio to one-channel mono during transcoding.
@@ -154,7 +154,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
         /// <returns></returns>
         SpeechRecognitionEvent RecognizeWithSession(string sessionId,
                                                     string contentType,
-                                                    FileStream audio,
+                                                    Stream audio,
                                                     string transferEncoding = "",
                                                     string model = "en-US_BroadbandModel",
                                                     string customizationId = "",
@@ -186,7 +186,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
         SpeechRecognitionEvent RecognizeWithSession(string sessionId,
                                                     string contentType,
                                                     Metadata metaData,
-                                                    FileStream audio,
+                                                    Stream audio,
                                                     string transferEncoding,
                                                     string model,
                                                     string customizationId);
@@ -269,7 +269,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
         /// <param name="corpusName">The name of the corpus that is to be added. The name cannot contain spaces and cannot be the string user, which is reserved by the service to denote custom words added or modified by the user. Use a localized name that matches the language of the custom model.</param>
         /// <param name="allowOverwrite">Indicates whether the specified corpus is to overwrite an existing corpus with the same name. If a corpus with the same name already exists, the request fails unless allow_overwrite is set to true; by default, the parameter is false. The parameter has no effect if a corpus with the same name does not already exist.</param>
         /// <param name="body">A plain text file that contains the training data for the corpus. Encode the file in UTF-8 if it contains non-ASCII characters; the service assumes UTF-8 encoding if it encounters non-ASCII characters. With cURL, use the --data-binary option to upload the file for the request.</param>
-        object AddCorpus(string customizationId, string corpusName, bool allowOverwrite, FileStream body);
+        object AddCorpus(string customizationId, string corpusName, bool allowOverwrite, Stream body);
 
         /// <summary>
         /// Lists information about all corpora that have been added to the specified custom language model. The information includes the total number of words and out-of-vocabulary (OOV) words, name, and status of each corpus. Only the owner of a custom model can use this method to list the model's corpora.

--- a/src/IBM.WatsonDeveloperCloud.SpeechToText/v1/Model/SpeechRecognitionAlternative.cs
+++ b/src/IBM.WatsonDeveloperCloud.SpeechToText/v1/Model/SpeechRecognitionAlternative.cs
@@ -38,7 +38,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1.Model
         /// Gets or sets time alignments for each word from transcript as a list of lists. Each inner list consists of three elements: the word followed by its start and end time in seconds. Example: `[["hello",0.0,1.2],["world",1.2,2.5]]`. Available only for the best alternative.
         /// </summary>
         [JsonProperty("timestamps")]
-        public List<string> Timestamps { get; set; }
+        public string[][] Timestamps { get; set; }
 
         /// <summary>
         /// Gets or sets confidence score for each word of the transcript as a list of lists. Each inner list consists of two elements: the word and its confidence score in the range of 0 to 1. Example: `[["hello",0.95],["world",0.866]]`. Available only for the best alternative and only in results marked as final.

--- a/src/IBM.WatsonDeveloperCloud.SpeechToText/v1/Model/SpeechRecognitionResult.cs
+++ b/src/IBM.WatsonDeveloperCloud.SpeechToText/v1/Model/SpeechRecognitionResult.cs
@@ -30,6 +30,12 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1.Model
         public bool Final { get; set; }
 
         /// <summary>
+        /// The numeric identifier that the service assigns to a speaker from the audio. Speaker IDs begin at 0 initially but can evolve and change across interim results (if supported by the method) and between interim and final results as the service processes the audio. They are not guaranteed to be sequential, contiguous, or ordered.
+        /// </summary>
+        [JsonProperty("speaker")]
+        public int Speaker { get; set; }
+
+        /// <summary>
         /// Gets or sets array of alternative transcripts.
         /// </summary>
         [JsonProperty("alternatives")]
@@ -46,5 +52,6 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1.Model
         /// </summary>
         [JsonProperty("word_alternatives")]
         public List<WordAlternativeResults> WordAlternativeResults { get; set; }
+
     }
 }

--- a/src/IBM.WatsonDeveloperCloud.SpeechToText/v1/Model/WordAlternativeResult.cs
+++ b/src/IBM.WatsonDeveloperCloud.SpeechToText/v1/Model/WordAlternativeResult.cs
@@ -31,6 +31,6 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1.Model
         /// Gets or sets word alternative hypothesis for a word from the input audio.
         /// </summary>
         [JsonProperty("word")]
-        public double Word { get; set; }
+        public string Word { get; set; }
     }
 }

--- a/src/IBM.WatsonDeveloperCloud.SpeechToText/v1/SpeechToTextService.cs
+++ b/src/IBM.WatsonDeveloperCloud.SpeechToText/v1/SpeechToTextService.cs
@@ -191,7 +191,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
             return result;
         }
 
-        public SpeechRecognitionEvent Recognize(string contentType, FileStream audio, string transferEncoding = "", string model = "en-US_BroadbandModel", string customizationId = "", bool? continuous = null, int? inactivityTimeout = null, string[] keywords = null, double? keywordsThreshold = null, int? maxAlternatives = null, double? wordAlternativesThreshold = null, bool? wordConfidence = null, bool? timestamps = null, bool profanityFilter = false, bool? smartFormatting = null, bool? speakerLabels = null)
+        public SpeechRecognitionEvent Recognize(string contentType, Stream audio, string transferEncoding = "", string model = "en-US_BroadbandModel", string customizationId = "", bool? continuous = null, int? inactivityTimeout = null, string[] keywords = null, double? keywordsThreshold = null, int? maxAlternatives = null, double? wordAlternativesThreshold = null, bool? wordConfidence = null, bool? timestamps = null, bool profanityFilter = false, bool? smartFormatting = null, bool? speakerLabels = null)
         {
             if (audio == null)
                 throw new ArgumentNullException($"{nameof(audio)}");
@@ -217,7 +217,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                                model: model);
         }
 
-        public SpeechRecognitionEvent Recognize(string contentType, Metadata metaData, FileStream audio, string transferEncoding = "", string model = "en-US_BroadbandModel", string customizationId = "")
+        public SpeechRecognitionEvent Recognize(string contentType, Metadata metaData, Stream audio, string transferEncoding = "", string model = "en-US_BroadbandModel", string customizationId = "")
         {
             if (metaData == null)
                 throw new ArgumentNullException($"{nameof(metaData)}");
@@ -235,7 +235,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                                model: model);
         }
 
-        public SpeechRecognitionEvent RecognizeWithSession(string sessionId, string contentType, FileStream audio, string transferEncoding = "", string model = "en-US_BroadbandModel", string customizationId = "", bool? continuous = null, int? inactivityTimeout = null, string[] keywords = null, double? keywordsThreshold = null, int? maxAlternatives = null, double? wordAlternativesThreshold = null, bool? wordConfidence = null, bool? timestamps = null, bool profanityFilter = false, bool? smartFormatting = null, bool? speakerLabels = null)
+        public SpeechRecognitionEvent RecognizeWithSession(string sessionId, string contentType, Stream audio, string transferEncoding = "", string model = "en-US_BroadbandModel", string customizationId = "", bool? continuous = null, int? inactivityTimeout = null, string[] keywords = null, double? keywordsThreshold = null, int? maxAlternatives = null, double? wordAlternativesThreshold = null, bool? wordConfidence = null, bool? timestamps = null, bool profanityFilter = false, bool? smartFormatting = null, bool? speakerLabels = null)
         {
             if (string.IsNullOrEmpty(sessionId))
                 throw new ArgumentNullException($"{nameof(sessionId)}");
@@ -264,7 +264,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                                model: model);
         }
 
-        public SpeechRecognitionEvent RecognizeWithSession(string sessionId, string contentType, Metadata metaData, FileStream audio, string transferEncoding = "", string model = "en-US_BroadbandModel", string customizationId = "")
+        public SpeechRecognitionEvent RecognizeWithSession(string sessionId, string contentType, Metadata metaData, Stream audio, string transferEncoding = "", string model = "en-US_BroadbandModel", string customizationId = "")
         {
             if (string.IsNullOrEmpty(sessionId))
                 throw new ArgumentNullException($"{nameof(sessionId)}");
@@ -285,7 +285,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                                model: model);
         }
 
-        private SpeechRecognitionEvent Recognize(string sessionId, string contentType, Metadata metaData, FileStream audio, string transferEncoding = "", string model = "", string customizationId = "", bool? continuous = null, int? inactivityTimeout = null, string[] keywords = null, double? keywordsThreshold = null, int? maxAlternatives = null, double? wordAlternativesThreshold = null, bool? wordConfidence = null, bool? timestamps = null, bool profanityFilter = false, bool? smartFormatting = null, bool? speakerLabels = null)
+        private SpeechRecognitionEvent Recognize(string sessionId, string contentType, Metadata metaData, Stream audio, string transferEncoding = "", string model = "", string customizationId = "", bool? continuous = null, int? inactivityTimeout = null, string[] keywords = null, double? keywordsThreshold = null, int? maxAlternatives = null, double? wordAlternativesThreshold = null, bool? wordConfidence = null, bool? timestamps = null, bool profanityFilter = false, bool? smartFormatting = null, bool? speakerLabels = null)
         {
             if (string.IsNullOrEmpty(contentType))
                 throw new ArgumentNullException($"{nameof(contentType)}");
@@ -378,7 +378,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                         request.WithArgument("model", model);
 
                     formData.Add(metadata, "metadata");
-                    formData.Add(audioContent, "upload", Path.GetFileName(audio.Name));
+                    formData.Add(audioContent, "upload");
 
                     request.WithBodyContent(formData);
                 }
@@ -611,7 +611,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
             return result;
         }
 
-        public object AddCorpus(string customizationId, string corpusName, bool allowOverwrite, FileStream body)
+        public object AddCorpus(string customizationId, string corpusName, bool allowOverwrite, Stream body)
         {
             if (string.IsNullOrEmpty(customizationId))
                 throw new ArgumentNullException($"{nameof(customizationId)}");
@@ -636,7 +636,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 var forcedGlossaryContent = new ByteArrayContent((body as Stream).ReadAllBytes());
                 forcedGlossaryContent.Headers.ContentType = MediaTypeHeaderValue.Parse(HttpMediaType.TEXT);
-                formData.Add(forcedGlossaryContent, "body", body.Name);
+                formData.Add(forcedGlossaryContent, "body");
 
                 result =
                     this.Client.WithAuthentication(this.UserName, this.Password)

--- a/test/IBM.WatsonDeveloperCloud.SpeechToText.UnitTests/SpeechToTextServiceUnitTest.cs
+++ b/test/IBM.WatsonDeveloperCloud.SpeechToText.UnitTests/SpeechToTextServiceUnitTest.cs
@@ -628,7 +628,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                                     new WordAlternativeResult()
                                     {
                                         Confidence = 0.5,
-                                        Word = 1
+                                        Word = "Word"
                                     }
                                 }
                             }
@@ -742,7 +742,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                                     new WordAlternativeResult()
                                     {
                                         Confidence = 0.5,
-                                        Word = 1
+                                        Word = "Word"
                                     }
                                 }
                             }

--- a/test/IBM.WatsonDeveloperCloud.SpeechToText.UnitTests/SpeechToTextServiceUnitTest.cs
+++ b/test/IBM.WatsonDeveloperCloud.SpeechToText.UnitTests/SpeechToTextServiceUnitTest.cs
@@ -594,9 +594,9 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                             new SpeechRecognitionAlternative()
                             {
                                 Confidence = 0.5,
-                                Timestamps = new List<string>()
+                                Timestamps = new[]
                                 {
-                                    "time_stamps"
+                                    new[] { "Word", "0.1","0.2"}
                                 },
                                 Transcript = "transcript",
                                 WordConfidence = new List<string>()
@@ -708,9 +708,9 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                             new SpeechRecognitionAlternative()
                             {
                                 Confidence = 0.5,
-                                Timestamps = new List<string>()
+                                Timestamps = new[]
                                 {
-                                    "time_stamps"
+                                    new[] { "Word", "0.1","0.2"}
                                 },
                                 Transcript = "transcript",
                                 WordConfidence = new List<string>()

--- a/test/IBM.WatsonDeveloperCloud.SpeechToText.UnitTests/SpeechToTextServiceUnitTest.cs
+++ b/test/IBM.WatsonDeveloperCloud.SpeechToText.UnitTests/SpeechToTextServiceUnitTest.cs
@@ -60,13 +60,13 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
         [TestMethod]
         public void Constructor_Without_Arguments()
         {
-            SpeechToTextService service = new SpeechToTextService();
+            ISpeechToTextService service = new SpeechToTextService();
         }
 
         [TestMethod]
         public void Constructor_With_Credentials()
         {
-            SpeechToTextService service = new SpeechToTextService("user_name", "password");
+            ISpeechToTextService service = new SpeechToTextService("user_name", "password");
         }
 
         [TestMethod]
@@ -109,7 +109,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var models = service.GetModels();
 
@@ -153,9 +153,9 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                                                                                string.Empty));
                   });
 
-            #endregion
+      #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var models = service.GetModels();
         }
@@ -194,7 +194,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var models = service.GetModel("model_name");
 
@@ -208,7 +208,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
         {
             IClient client = Substitute.For<IClient>();
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var models = service.GetModel(string.Empty);
         }
@@ -234,7 +234,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var models = service.GetModel("model_name");
         }
@@ -273,7 +273,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var models = service.CreateSession("model_name");
 
@@ -312,7 +312,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var models = service.CreateSession(string.Empty);
 
@@ -342,7 +342,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var models = service.CreateSession(string.Empty);
         }
@@ -381,7 +381,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var sessionStatus = service.GetSessionStatus(new Session() { SessionId = "session_id" });
 
@@ -420,7 +420,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var sessionStatus = service.GetSessionStatus(string.Empty);
         }
@@ -457,7 +457,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var sessionStatus = service.GetSessionStatus("session_id");
         }
@@ -496,7 +496,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.DeleteSession(new Session() { SessionId = "session_id" });
 
@@ -533,7 +533,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.DeleteSession(string.Empty);
         }
@@ -567,7 +567,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.DeleteSession("session_id");
         }
@@ -661,7 +661,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.Recognize(contentType: HttpMediaType.AUDIO_WAV,
@@ -778,7 +778,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.RecognizeWithSession(sessionId: "sessionId",
@@ -810,7 +810,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.RecognizeWithSession(sessionId: string.Empty,
@@ -842,7 +842,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.RecognizeWithSession(sessionId: null,
@@ -874,7 +874,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.RecognizeWithSession(sessionId: "sessionId",
@@ -922,7 +922,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                service.Recognize(contentType: HttpMediaType.AUDIO_WAV,
@@ -981,7 +981,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                service.RecognizeWithSession(sessionId: "sessionId",
@@ -1022,7 +1022,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                service.RecognizeWithSession(sessionId: string.Empty,
@@ -1063,7 +1063,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                service.RecognizeWithSession(sessionId: null,
@@ -1104,7 +1104,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                service.RecognizeWithSession(sessionId: "sessionId",
@@ -1145,7 +1145,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                service.RecognizeWithSession(sessionId: "sessionId",
@@ -1186,7 +1186,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.Recognize(contentType: null,
@@ -1218,7 +1218,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.Recognize(contentType: "contentType",
@@ -1250,7 +1250,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.Recognize(contentType: null,
@@ -1283,7 +1283,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.Recognize(contentType: "contentType",
@@ -1316,7 +1316,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.Recognize(contentType: "contentType",
@@ -1345,7 +1345,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.Recognize(contentType: HttpMediaType.AUDIO_WAV,
@@ -1385,7 +1385,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var recognitionEvent = service.ObserveResult("session_id", 1, true);
 
@@ -1418,7 +1418,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var recognitionEvent = service.ObserveResult(string.Empty);
         }
@@ -1446,7 +1446,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var recognitionEvent = service.ObserveResult("session_id");
         }
@@ -1478,7 +1478,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.CreateCustomModel(baseModelName: "base_model_name",
@@ -1517,7 +1517,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.CreateCustomModel(new CustomModel()
@@ -1559,7 +1559,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.CreateCustomModel(new CustomModel()
@@ -1597,7 +1597,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.CreateCustomModel(new CustomModel()
@@ -1634,7 +1634,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.CreateCustomModel(new CustomModel()
@@ -1687,7 +1687,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCustomModels();
@@ -1721,7 +1721,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCustomModels(null);
@@ -1748,7 +1748,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCustomModels();
@@ -1790,7 +1790,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCustomModel("custom_model_id");
@@ -1816,7 +1816,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCustomModel(null);
@@ -1843,7 +1843,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCustomModel("custom_model_id");
@@ -1871,7 +1871,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.TrainCustomModel("custom_model_id");
 
@@ -1900,7 +1900,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.TrainCustomModel(null);
 
@@ -1928,7 +1928,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.TrainCustomModel("custom_model_id");
         }
@@ -1955,7 +1955,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.ResetCustomModel("custom_model_id");
 
@@ -1984,7 +1984,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.ResetCustomModel(null);
 
@@ -2012,7 +2012,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.ResetCustomModel("custom_model_id");
         }
@@ -2039,7 +2039,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.UpgradeCustomModel("custom_model_id");
 
@@ -2068,7 +2068,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.UpgradeCustomModel(null);
         }
@@ -2094,7 +2094,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.UpgradeCustomModel("custom_model_id");
         }
@@ -2121,7 +2121,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.DeleteCustomModel("custom_model_id");
 
@@ -2150,7 +2150,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.DeleteCustomModel(null);
         }
@@ -2176,7 +2176,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
 
             #endregion
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.DeleteCustomModel("custom_model_id");
         }
@@ -2201,7 +2201,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                    .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCorpus("customization_id", "corpus_name", true, new FileStream("body", FileMode.Create));
 
@@ -2228,7 +2228,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                    .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCorpus(null, "corpus_name", true, new FileStream("body_customizationId_null", FileMode.Create));
         }
@@ -2253,7 +2253,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                    .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCorpus("customization_id", null, true, new FileStream("body_corpusName_null", FileMode.Create));
         }
@@ -2278,7 +2278,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                    .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCorpus("customization_id", "user", true, new FileStream("body_corpus_name_is_user", FileMode.Create));
         }
@@ -2303,7 +2303,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                    .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCorpus("customization_id", "corpus name with white spaces", true, new FileStream("body_corpus_name_whiteSpaces", FileMode.Create));
         }
@@ -2328,7 +2328,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                    .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCorpus("customization_id", "corpus_name", true, null);
         }
@@ -2350,7 +2350,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                                                                                string.Empty));
                  });
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCorpus("customization_id", "corpus_name", true, new FileStream("body_catch_exception", FileMode.Create));
         }
@@ -2386,7 +2386,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.As<Corpora>()
                    .Returns(Task.FromResult(response));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCorpora("customization_id");
@@ -2428,7 +2428,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.As<Corpora>()
                    .Returns(Task.FromResult(response));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCorpora(null);
@@ -2465,7 +2465,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.As<Corpora>()
                    .Returns(Task.FromResult(response));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCorpora(string.Empty);
@@ -2488,7 +2488,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                                                                                 string.Empty));
                   });
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCorpora("customization_id");
@@ -2519,7 +2519,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.As<Corpus>()
                    .Returns(Task.FromResult(response));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.GetCorpus("customization_id", "corpus_name");
@@ -2554,7 +2554,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.As<Corpus>()
                    .Returns(Task.FromResult(response));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.GetCorpus(null, "corpus_name");
@@ -2585,7 +2585,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.As<Corpus>()
                    .Returns(Task.FromResult(response));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.GetCorpus(string.Empty, "corpus_name");
@@ -2616,7 +2616,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.As<Corpus>()
                    .Returns(Task.FromResult(response));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.GetCorpus("customization_id", null);
@@ -2647,7 +2647,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.As<Corpus>()
                    .Returns(Task.FromResult(response));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.GetCorpus("customization_id", string.Empty);
@@ -2670,7 +2670,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                                                                                 string.Empty));
                   });
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.GetCorpus("customization_id", "corpus_name");
@@ -2691,7 +2691,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                    .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.DeleteCorpus("customization_id", "corpus_name");
 
@@ -2713,7 +2713,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                     .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.DeleteCorpus(null, "corpus_name");
         }
@@ -2733,7 +2733,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                     .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.DeleteCorpus(string.Empty, "corpus_name");
         }
@@ -2753,7 +2753,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                     .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.DeleteCorpus("customization_id", null);
         }
@@ -2773,7 +2773,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                     .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.DeleteCorpus("customization_id", string.Empty);
         }
@@ -2795,7 +2795,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                                                                                 string.Empty));
                   });
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.DeleteCorpus("customization_id", "corpus_name");
         }
@@ -2818,7 +2818,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                    .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCustomWords("customization_id",
                                   new Words()
@@ -2876,7 +2876,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                    .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCustomWords(null,
                                   new Words()
@@ -2934,7 +2934,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                    .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCustomWords(string.Empty,
                                   new Words()
@@ -2990,7 +2990,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                    .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCustomWords("customization_id", null);
         }
@@ -3012,7 +3012,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                                                                                 string.Empty));
                   });
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCustomWords("customization_id",
                                   new Words()
@@ -3068,7 +3068,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                    .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCustomWord("customization_id",
                                   "word_name",
@@ -3102,7 +3102,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                    .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCustomWord(null,
                                   "word_name",
@@ -3134,7 +3134,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                    .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCustomWord(string.Empty,
                                   "word_name",
@@ -3166,7 +3166,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                    .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCustomWord("customization_id",
                                   null,
@@ -3198,7 +3198,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                    .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCustomWord("customization_id",
                                   string.Empty,
@@ -3230,7 +3230,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                    .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCustomWord("customization_id",
                                  "word_name",
@@ -3254,7 +3254,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                                                                                 string.Empty));
                   });
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.AddCustomWord("customization_id",
                                   "word_name",
@@ -3313,7 +3313,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                        }
                    }));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCustomWords("customization_id", null, null);
@@ -3369,7 +3369,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                        }
                    }));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCustomWords("customization_id", WordType.All, null);
@@ -3425,7 +3425,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                        }
                    }));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCustomWords("customization_id", null, Sort.AscendingAlphabetical);
@@ -3481,7 +3481,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                        }
                    }));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCustomWords("customization_id", null, Sort.AscendingCount);
@@ -3537,7 +3537,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                        }
                    }));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCustomWords("customization_id", null, Sort.DescendingAlphabetical);
@@ -3593,7 +3593,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                        }
                    }));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCustomWords("customization_id", null, Sort.DescendingCount);
@@ -3609,7 +3609,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
         {
             IClient client = Substitute.For<IClient>();
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCustomWords(null, null, null);
@@ -3620,7 +3620,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
         {
             IClient client = Substitute.For<IClient>();
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCustomWords(string.Empty, null, null);
@@ -3643,7 +3643,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                                                                                 string.Empty));
                   });
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCustomWords("customization_id", null, null);
@@ -3685,7 +3685,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                        Word = "word"
                    }));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             var result =
                 service.ListCustomWord("customization_id", "word_name");
@@ -3700,7 +3700,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
         {
             IClient client = Substitute.For<IClient>();
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.ListCustomWord(null, "word_name");
         }
@@ -3710,7 +3710,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
         {
             IClient client = Substitute.For<IClient>();
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.ListCustomWord(string.Empty, "word_name");
         }
@@ -3720,7 +3720,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
         {
             IClient client = Substitute.For<IClient>();
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.ListCustomWord("customization_id", null);
         }
@@ -3730,7 +3730,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
         {
             IClient client = Substitute.For<IClient>();
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.ListCustomWord("customization_id", string.Empty);
         }
@@ -3752,7 +3752,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                                                                                 string.Empty));
                   });
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.ListCustomWord("customization_id", "word_name");
         }
@@ -3772,7 +3772,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
             request.AsString()
                    .Returns(Task.FromResult("{}"));
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.DeleteCustomWord("customization_id", "word_name");
 
@@ -3784,7 +3784,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
         {
             IClient client = Substitute.For<IClient>();
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.DeleteCustomWord(null, "word_name");
         }
@@ -3794,7 +3794,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
         {
             IClient client = Substitute.For<IClient>();
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.DeleteCustomWord(string.Empty, "word_name");
         }
@@ -3804,7 +3804,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
         {
             IClient client = Substitute.For<IClient>();
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.DeleteCustomWord("customization_id", null);
         }
@@ -3814,7 +3814,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
         {
             IClient client = Substitute.For<IClient>();
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.DeleteCustomWord("customization_id", string.Empty);
         }
@@ -3836,7 +3836,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.UnitTest
                                                                                 string.Empty));
                   });
 
-            SpeechToTextService service = new SpeechToTextService(client);
+            ISpeechToTextService service = new SpeechToTextService(client);
 
             service.DeleteCustomWord("customization_id", "corpus_name");
         }


### PR DESCRIPTION
### Summary

 1. Interface default params should match default params of implementation so the interface can be used as described in examples.
 2.  Replaced `FileStream` with `Stream` and removed usage of filename passed to form. (API does not seem to require this). By using `FileStream`, we're assuming the source of the stream is a file, changing this to `Stream` allows the consumer of the library to determine what type of stream it is.

This does not break anything.


