### PR TITLE
use Master to tag and release from now on

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,7 @@ after_build:
     .\packages\Doxygen.1.8.13\tools\doxygen.exe Doxyfile
 
 
-    If($branchName -eq "development" -or $branchName -eq $env:APPVEYOR_REPO_TAG_NAME -or $branchName -eq "release")
+    If($branchName -eq "development" -or $branchName -eq $env:APPVEYOR_REPO_TAG_NAME -or $branchName -eq "master")
 
     {
         git config --global user.email "wps@us.ibm.com"
@@ -119,5 +119,5 @@ deploy:
   api_key:
     secure: AaqUbQ5mJm8bYbpNH7GbAzYl45fZZHpqeNdtSd0wQNxjgYmLmvtMU5eByA/mkhxB
   on:
-    branch: release
+    branch: master
     APPVEYOR_REPO_TAG: true


### PR DESCRIPTION
### Summary

From now on I want to use `release` branch to prep for release. I want to tag and push `master` branch to nuget. Also I generate documentation on `master` branch rather than release.