### PR TITLE
Revised user-agent to standard format

### DIFF
--- a/src/IBM.WatsonDeveloperCloud/Constants.cs
+++ b/src/IBM.WatsonDeveloperCloud/Constants.cs
@@ -26,6 +26,6 @@ namespace IBM.WatsonDeveloperCloud
         /// The version number for this SDK build. Added to the header in 
         /// each request as `User-Agent`.
         /// </summary>
-        public const string SDK_VERSION = "watson-apis-dotnet-standard-sdk/1.1.0";
+        public const string SDK_VERSION = "watson-apis-dotnet-sdk/1.2.0";
     }
 }


### PR DESCRIPTION
### Summary

User agent is now following the format `watson-apis-[language]-sdk/[version]`