### PR TITLE
Fixed: validation if response is json

### DIFF
--- a/src/IBM.WatsonDeveloperCloud/Http/Filters/ErrorFilter.cs
+++ b/src/IBM.WatsonDeveloperCloud/Http/Filters/ErrorFilter.cs
@@ -32,9 +32,20 @@ namespace IBM.WatsonDeveloperCloud.Http.Filters
                 ServiceResponseException exception =
                     new ServiceResponseException(response, responseMessage, $"The API query failed with status code {responseMessage.StatusCode}: {responseMessage.ReasonPhrase}");
 
-                var jsonError = responseMessage.Content.ReadAsStringAsync().Result;
+                var error = responseMessage.Content.ReadAsStringAsync().Result;
 
-                exception.Error = JsonConvert.DeserializeObject<Error>(jsonError);
+                if (responseMessage.Content.Headers.ContentType.MediaType == HttpMediaType.APPLICATION_JSON)
+                {
+                    exception.Error = JsonConvert.DeserializeObject<Error>(error);
+                }
+                else
+                {
+                    exception.Error = new Error()
+                    {
+                        CodeDescription = responseMessage.StatusCode.ToString(),
+                        Message = error
+                    };
+                }
 
                 throw exception;
             }


### PR DESCRIPTION
### Summary

A validation has been added in the [ErrorFilter](https://github.com/watson-developer-cloud/dotnet-standard-sdk/blob/development/src/IBM.WatsonDeveloperCloud/Http/Filters/ErrorFilter.cs) class, whether it will check whether the return is a json. If positive, we will deserialize to type [Error](https://github.com/watson-developer-cloud/dotnet-standard-sdk/blob/development/src/IBM.WatsonDeveloperCloud/Http/Exceptions/Error.cs), if not, we will get the message returned and instantiate a new object of type [Error](https://github.com/watson-developer-cloud/dotnet-standard-sdk/blob/development/src/IBM.WatsonDeveloperCloud/Http/Exceptions/Error.cs).