### PR TITLE
Appveyor/Nuget workaround

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,6 @@ environment:
   CRED_SECRET:
     secure: eEcA/09B7XzeTSb3GlaeqcWfQ/TemXxAq9/0AFM5+z8=
   VCAP_SERVICES: C:\projects\dotnet-standard-sdk\config
-init:
-- ps: '[System.IO.File]::AppendAllText("C:\Windows\System32\drivers\etc\hosts", "`n93.184.221.200  api.nuget.org")'
 install:
 - cmd: >-
     rm -rf packages


### PR DESCRIPTION
### Summary
Appveyor has been unable to connect to Nuget. They attribute it to 

> The issue is a "broken" route between Rackspace data center and US-based CDN edge server for api.nuget.org. Unfortunately, there is no ETA yet. We continue working with nuget team to resolve the issue as soon as possible. 

This PR removes their suggested workaround of routing through Europe CDN server.