### PR TITLE
Enable Collections integration tests in Visual Recognition

### DIFF
--- a/test/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests/VisualRecognitionServiceIntegrationTests.cs
+++ b/test/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests/VisualRecognitionServiceIntegrationTests.cs
@@ -16,7 +16,7 @@
 */
 
 //  Comment to enable testing of collections, collection images and similarity search.
-#define ENABLE_COLLECTIONS
+//#define ENABLE_COLLECTIONS
 
 using IBM.WatsonDeveloperCloud.VisualRecognition.v3.Model;
 using IBM.WatsonDeveloperCloud.Http.Extensions;

--- a/test/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests/VisualRecognitionServiceIntegrationTests.cs
+++ b/test/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests/VisualRecognitionServiceIntegrationTests.cs
@@ -15,6 +15,9 @@
 *
 */
 
+//  Comment to enable testing of collections, collection images and similarity search.
+#define ENABLE_COLLECTIONS
+
 using IBM.WatsonDeveloperCloud.VisualRecognition.v3.Model;
 using IBM.WatsonDeveloperCloud.Http.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -34,9 +37,7 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests
         private string _imageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/b/bb/Kittyply_edit1.jpg/1200px-Kittyply_edit1.jpg";
         private string _faceUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8d/President_Barack_Obama.jpg/220px-President_Barack_Obama.jpg";
         private string _localGiraffeFilePath = @"VisualRecognitionTestData\giraffe_to_classify.jpg";
-        //private string _localImageMetadataPath = @"VisualRecognitionTestData\imageMetadata.json";
         private string _localFaceFilePath = @"VisualRecognitionTestData\obama.jpg";
-        //private string _localTurtleFilePath = @"VisualRecognitionTestData\turtle_to_classify.jpg";
         private string _localGiraffePositiveExamplesFilePath = @"VisualRecognitionTestData\giraffe_positive_examples.zip";
         private string _giraffeClassname = "giraffe";
         private string _localTurtlePositiveExamplesFilePath = @"VisualRecognitionTestData\turtle_positive_examples.zip";
@@ -44,9 +45,13 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests
         private string _localNegativeExamplesFilePath = @"VisualRecognitionTestData\negative_examples.zip";
         private string _createdClassifierName = "dotnet-standard-test-classifier";
         private static string _createdClassifierId = "";
-        //private string _collectionNameToCreate = "dotnet-standard-test-collection";
-        //private static string _createdCollectionId = "";
-        //private static string _addedImageId = "";
+#if ENABLE_COLLECTIONS
+        private string _localImageMetadataPath = @"VisualRecognitionTestData\imageMetadata.json";
+        private string _localTurtleFilePath = @"VisualRecognitionTestData\turtle_to_classify.jpg";
+        private string _collectionNameToCreate = "dotnet-standard-test-collection";
+        private static string _createdCollectionId = "";
+        private static string _addedImageId = "";
+#endif
         AutoResetEvent autoEvent = new AutoResetEvent(false);
 
         [TestInitialize]
@@ -192,194 +197,196 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests
             }
         }
 
-        //[TestMethod]
-        //public void t09_GetCollections_Success()
-        //{
-        //    VisualRecognitionService service = new VisualRecognitionService();
-        //    service.SetCredential(apikey);
+#if ENABLE_COLLECTIONS
+        [TestMethod]
+        public void t09_GetCollections_Success()
+        {
+            VisualRecognitionService service = new VisualRecognitionService();
+            service.SetCredential(apikey);
 
-        //    var result = service.GetCollections();
+            var result = service.GetCollections();
 
-        //    Assert.IsNotNull(result);
-        //}
+            Assert.IsNotNull(result);
+        }
 
-        //[TestMethod]
-        //public void t10_CreateCollection_Success()
-        //{
-        //    DeleteDotnetCollections();
+        [TestMethod]
+        public void t10_CreateCollection_Success()
+        {
+            DeleteDotnetCollections();
 
-        //    VisualRecognitionService service = new VisualRecognitionService();
-        //    service.SetCredential(apikey);
+            VisualRecognitionService service = new VisualRecognitionService();
+            service.SetCredential(apikey);
 
-        //    var result = service.CreateCollection(_collectionNameToCreate);
+            var result = service.CreateCollection(_collectionNameToCreate);
 
-        //    _createdCollectionId = result.CollectionId;
-        //    Console.WriteLine(string.Format("Created collection {0}", _createdCollectionId));
+            _createdCollectionId = result.CollectionId;
+            Console.WriteLine(string.Format("Created collection {0}", _createdCollectionId));
 
-        //    Assert.IsNotNull(result);
-        //    Assert.IsTrue(!string.IsNullOrEmpty(_createdCollectionId));
-        //}
+            Assert.IsNotNull(result);
+            Assert.IsTrue(!string.IsNullOrEmpty(_createdCollectionId));
+        }
 
-        //[TestMethod]
-        //public void t11_GetCollection_Success()
-        //{
-        //    if (string.IsNullOrEmpty(_createdCollectionId))
-        //        Assert.Fail("Created collection ID is null or empty.");
+        [TestMethod]
+        public void t11_GetCollection_Success()
+        {
+            if (string.IsNullOrEmpty(_createdCollectionId))
+                Assert.Fail("Created collection ID is null or empty.");
 
-        //    VisualRecognitionService service = new VisualRecognitionService();
-        //    service.SetCredential(apikey);
+            VisualRecognitionService service = new VisualRecognitionService();
+            service.SetCredential(apikey);
 
-        //    var result = service.GetCollection(_createdCollectionId);
+            var result = service.GetCollection(_createdCollectionId);
 
-        //    Assert.IsNotNull(result);
-        //    Assert.IsTrue(result.CollectionId == _createdCollectionId);
-        //}
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.CollectionId == _createdCollectionId);
+        }
 
-        //[TestMethod]
-        //public void t12_GetCollectionImages_Success()
-        //{
-        //    if (string.IsNullOrEmpty(_createdCollectionId))
-        //        Assert.Fail("Created collection ID is null or empty.");
+        [TestMethod]
+        public void t12_GetCollectionImages_Success()
+        {
+            if (string.IsNullOrEmpty(_createdCollectionId))
+                Assert.Fail("Created collection ID is null or empty.");
 
-        //    VisualRecognitionService service = new VisualRecognitionService();
-        //    service.SetCredential(apikey);
+            VisualRecognitionService service = new VisualRecognitionService();
+            service.SetCredential(apikey);
 
-        //    var result = service.GetCollectionImages(_createdCollectionId);
+            var result = service.GetCollectionImages(_createdCollectionId);
 
-        //    Assert.IsNotNull(result);
-        //}
+            Assert.IsNotNull(result);
+        }
 
-        //[TestMethod]
-        //public void t13_AddCollectionImages_Success()
-        //{
-        //    VisualRecognitionService service = new VisualRecognitionService();
-        //    service.SetCredential(apikey);
+        [TestMethod]
+        public void t13_AddCollectionImages_Success()
+        {
+            VisualRecognitionService service = new VisualRecognitionService();
+            service.SetCredential(apikey);
 
-        //    using (FileStream imageStream = File.OpenRead(_localGiraffeFilePath), metadataStream = File.OpenRead(_localImageMetadataPath))
-        //    {
-        //        var result = service.AddImage(_createdCollectionId, imageStream.ReadAllBytes(), Path.GetFileName(_localGiraffeFilePath), metadataStream.ReadAllBytes());
+            using (FileStream imageStream = File.OpenRead(_localGiraffeFilePath), metadataStream = File.OpenRead(_localImageMetadataPath))
+            {
+                var result = service.AddImage(_createdCollectionId, imageStream.ReadAllBytes(), Path.GetFileName(_localGiraffeFilePath), metadataStream.ReadAllBytes());
 
-        //        _addedImageId = result.Images[0].ImageId;
-        //        Console.WriteLine(string.Format("Added image {0}", _addedImageId));
+                _addedImageId = result.Images[0].ImageId;
+                Console.WriteLine(string.Format("Added image {0}", _addedImageId));
 
-        //        Assert.IsNotNull(result);
-        //        Assert.IsTrue(result.ImagesProcessed > 0);
-        //        Assert.IsTrue(!string.IsNullOrEmpty(_addedImageId));
-        //    }
-        //}
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result.ImagesProcessed > 0);
+                Assert.IsTrue(!string.IsNullOrEmpty(_addedImageId));
+            }
+        }
 
-        //[TestMethod]
-        //public void t14_GetCollectionImage_Success()
-        //{
-        //    if (string.IsNullOrEmpty(_createdCollectionId))
-        //        Assert.Fail("Created collection ID is null or empty.");
+        [TestMethod]
+        public void t14_GetCollectionImage_Success()
+        {
+            if (string.IsNullOrEmpty(_createdCollectionId))
+                Assert.Fail("Created collection ID is null or empty.");
 
-        //    if (string.IsNullOrEmpty(_addedImageId))
-        //        Assert.Fail("Added image ID is null or empty.");
+            if (string.IsNullOrEmpty(_addedImageId))
+                Assert.Fail("Added image ID is null or empty.");
 
-        //    VisualRecognitionService service = new VisualRecognitionService();
-        //    service.SetCredential(apikey);
+            VisualRecognitionService service = new VisualRecognitionService();
+            service.SetCredential(apikey);
 
-        //    var result = service.GetImage(_createdCollectionId, _addedImageId);
+            var result = service.GetImage(_createdCollectionId, _addedImageId);
 
-        //    Assert.IsNotNull(result);
-        //    Assert.IsTrue(result.ImageId == _addedImageId);
-        //}
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.ImageId == _addedImageId);
+        }
 
-        //[TestMethod]
-        //public void t15_GetCollectionImageMetadata_Success()
-        //{
-        //    if (string.IsNullOrEmpty(_createdCollectionId))
-        //        Assert.Fail("Created collection ID is null or empty.");
+        [TestMethod]
+        public void t15_GetCollectionImageMetadata_Success()
+        {
+            if (string.IsNullOrEmpty(_createdCollectionId))
+                Assert.Fail("Created collection ID is null or empty.");
 
-        //    if (string.IsNullOrEmpty(_addedImageId))
-        //        Assert.Fail("Added image ID is null or empty.");
+            if (string.IsNullOrEmpty(_addedImageId))
+                Assert.Fail("Added image ID is null or empty.");
 
-        //    VisualRecognitionService service = new VisualRecognitionService();
-        //    service.SetCredential(apikey);
+            VisualRecognitionService service = new VisualRecognitionService();
+            service.SetCredential(apikey);
 
-        //    var result = service.GetMetadata(_createdCollectionId, _addedImageId);
+            var result = service.GetMetadata(_createdCollectionId, _addedImageId);
 
-        //    Assert.IsNotNull(result);
-        //}
+            Assert.IsNotNull(result);
+        }
 
-        //[TestMethod]
-        //public void t16_AddCollectionImageMetadata_Success()
-        //{
-        //    if (string.IsNullOrEmpty(_createdCollectionId))
-        //        Assert.Fail("Created collection ID is null or empty.");
+        [TestMethod]
+        public void t16_AddCollectionImageMetadata_Success()
+        {
+            if (string.IsNullOrEmpty(_createdCollectionId))
+                Assert.Fail("Created collection ID is null or empty.");
 
-        //    if (string.IsNullOrEmpty(_addedImageId))
-        //        Assert.Fail("Added image ID is null or empty.");
+            if (string.IsNullOrEmpty(_addedImageId))
+                Assert.Fail("Added image ID is null or empty.");
 
-        //    VisualRecognitionService service = new VisualRecognitionService();
-        //    service.SetCredential(apikey);
+            VisualRecognitionService service = new VisualRecognitionService();
+            service.SetCredential(apikey);
 
-        //    using (FileStream metadataStream = File.OpenRead(_localImageMetadataPath))
-        //    {
-        //        var result = service.AddImageMetadata(_createdCollectionId, _addedImageId, metadataStream.ReadAllBytes());
+            using (FileStream metadataStream = File.OpenRead(_localImageMetadataPath))
+            {
+                var result = service.AddImageMetadata(_createdCollectionId, _addedImageId, metadataStream.ReadAllBytes());
 
-        //        Assert.IsNotNull(result);
-        //        Assert.IsTrue(result.Count > 0);
-        //    }
-        //}
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result.Count > 0);
+            }
+        }
 
-        //[TestMethod]
-        //public void t17_DeleteCollectionImageMetadata_Success()
-        //{
-        //    VisualRecognitionService service = new VisualRecognitionService();
-        //    service.SetCredential(apikey);
+        [TestMethod]
+        public void t17_DeleteCollectionImageMetadata_Success()
+        {
+            VisualRecognitionService service = new VisualRecognitionService();
+            service.SetCredential(apikey);
 
-        //    var result = service.DeleteImageMetadata(_createdCollectionId, _addedImageId);
+            var result = service.DeleteImageMetadata(_createdCollectionId, _addedImageId);
 
-        //    Assert.IsNotNull(result);
-        //}
+            Assert.IsNotNull(result);
+        }
 
-        //[TestMethod]
-        //public void t18_FindSimilar_Success()
-        //{
-        //    VisualRecognitionService service = new VisualRecognitionService();
-        //    service.SetCredential(apikey);
+        [TestMethod]
+        public void t18_FindSimilar_Success()
+        {
+            VisualRecognitionService service = new VisualRecognitionService();
+            service.SetCredential(apikey);
 
-        //    using (FileStream imageStream = File.OpenRead(_localTurtleFilePath))
-        //    {
-        //        var result = service.FindSimilar(_createdCollectionId, imageStream.ReadAllBytes(), Path.GetFileName(_localGiraffeFilePath));
+            using (FileStream imageStream = File.OpenRead(_localTurtleFilePath))
+            {
+                var result = service.FindSimilar(_createdCollectionId, imageStream.ReadAllBytes(), Path.GetFileName(_localGiraffeFilePath));
 
-        //        Assert.IsNotNull(result);
-        //        Assert.IsTrue(result.ImagesProcessed > 0);
-        //    }
-        //}
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result.ImagesProcessed > 0);
+            }
+        }
 
-        //[TestMethod]
-        //public void t19_DeleteCollectionImage_Success()
-        //{
-        //    if (string.IsNullOrEmpty(_createdCollectionId))
-        //        Assert.Fail("Created collection ID is null or empty.");
+        [TestMethod]
+        public void t19_DeleteCollectionImage_Success()
+        {
+            if (string.IsNullOrEmpty(_createdCollectionId))
+                Assert.Fail("Created collection ID is null or empty.");
 
-        //    if (string.IsNullOrEmpty(_addedImageId))
-        //        Assert.Fail("Added image ID is null or empty.");
+            if (string.IsNullOrEmpty(_addedImageId))
+                Assert.Fail("Added image ID is null or empty.");
 
-        //    VisualRecognitionService service = new VisualRecognitionService();
-        //    service.SetCredential(apikey);
+            VisualRecognitionService service = new VisualRecognitionService();
+            service.SetCredential(apikey);
 
-        //    var result = service.DeleteImage(_createdCollectionId, _addedImageId);
+            var result = service.DeleteImage(_createdCollectionId, _addedImageId);
 
-        //    Assert.IsNotNull(result);
-        //}
+            Assert.IsNotNull(result);
+        }
 
-        //[TestMethod]
-        //public void t20_DeleteCollection_Success()
-        //{
-        //    if (string.IsNullOrEmpty(_createdCollectionId))
-        //        Assert.Fail("Created collection ID is null or empty.");
+        [TestMethod]
+        public void t20_DeleteCollection_Success()
+        {
+            if (string.IsNullOrEmpty(_createdCollectionId))
+                Assert.Fail("Created collection ID is null or empty.");
 
-        //    VisualRecognitionService service = new VisualRecognitionService();
-        //    service.SetCredential(apikey);
+            VisualRecognitionService service = new VisualRecognitionService();
+            service.SetCredential(apikey);
 
-        //    var result = service.DeleteCollection(_createdCollectionId);
+            var result = service.DeleteCollection(_createdCollectionId);
 
-        //    Assert.IsNotNull(result);
-        //}
+            Assert.IsNotNull(result);
+        }
+#endif
 
         [TestMethod]
         public void t21_DeleteClassifier_Success()
@@ -419,30 +426,32 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests
             return result.Status.ToLower() == "ready";
         }
 
-        //private void DeleteDotnetCollections()
-        //{
-        //    VisualRecognitionService service = new VisualRecognitionService();
-        //    service.SetCredential(apikey);
+#if ENABLE_COLLECTIONS
+        private void DeleteDotnetCollections()
+        {
+            VisualRecognitionService service = new VisualRecognitionService();
+            service.SetCredential(apikey);
 
-        //    List<string> collectionIdsToDelete = new List<string>();
+            List<string> collectionIdsToDelete = new List<string>();
 
-        //    var collections = service.GetCollections();
+            var collections = service.GetCollections();
 
-        //    foreach (CreateCollection collection in collections.Collections)
-        //    {
-        //        string name = collection.Name;
-        //        string id = collection.CollectionId;
+            foreach (CreateCollection collection in collections.Collections)
+            {
+                string name = collection.Name;
+                string id = collection.CollectionId;
 
-        //        if (name == _collectionNameToCreate)
-        //            collectionIdsToDelete.Add(id);
-        //    }
+                if (name == _collectionNameToCreate)
+                    collectionIdsToDelete.Add(id);
+            }
 
-        //    if (collectionIdsToDelete.Count > 0)
-        //    {
-        //        foreach (string collectionIdToDelete in collectionIdsToDelete)
-        //            service.DeleteCollection(collectionIdToDelete);
-        //    }
-        //}
+            if (collectionIdsToDelete.Count > 0)
+            {
+                foreach (string collectionIdToDelete in collectionIdsToDelete)
+                    service.DeleteCollection(collectionIdToDelete);
+            }
+        }
+#endif
 
         private bool ContainsClass(GetClassifiersPerClassifierVerbose result, string classname)
         {


### PR DESCRIPTION
### Summary
Creating collections in Visual Recognition was failing. Visual Recognition team provisioned new Collections slots so these tests should not fail anymore. Added ifdef to easily deactivate tests.