### PR TITLE
Updated conversation doc link

### DIFF
--- a/src/IBM.WatsonDeveloperCloud.Conversation.v1/README.md
+++ b/src/IBM.WatsonDeveloperCloud.Conversation.v1/README.md
@@ -365,4 +365,4 @@ List the events from the log of a workspace.
 var result = _conversation.ListLogs(<workspaceId>);
 ```
 
-[conversation]:https://www.ibm.com/watson/developercloud/doc/conversation/index.html
+[conversation]:https://console.bluemix.net/docs/services/conversation/index.html#about


### PR DESCRIPTION
### Summary

Updated the link that went to the WDC for Conversation service docs. They have moved to Bluemix Docs.

