### PR TITLE
4609 iam url

### DIFF
--- a/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/VisualRecognitionService.cs
+++ b/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/VisualRecognitionService.cs
@@ -67,7 +67,7 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3
                 throw new ArgumentNullException("versionDate cannot be null.");
 
             VersionDate = versionDate;
-            this.Endpoint = options.IamUrl;
+            this.Endpoint = options.ServiceUrl;
 
 
             _tokenManager = new TokenManager(options);

--- a/src/IBM.WatsonDeveloperCloud/Util/Credentials.cs
+++ b/src/IBM.WatsonDeveloperCloud/Util/Credentials.cs
@@ -96,11 +96,21 @@ namespace IBM.WatsonDeveloperCloud.Util
     /// </summary>
     public class TokenOptions
     {
-        [JsonProperty("iamApiKey", NullValueHandling = NullValueHandling.Ignore)]
+        /// <summary>
+        /// The IAM Apikey for the service instance. If provided, The SDK will manage authentication through tokens.
+        /// </summary>
         public string IamApiKey { get; set; }
-        [JsonProperty("iamAcessToken", NullValueHandling = NullValueHandling.Ignore)]
+        /// <summary>
+        /// The access token for the service instance. If provided, the SDK will not manage authentication through tokens. 
+        /// </summary>
         public string IamAccessToken { get; set; }
-        [JsonProperty("iamUrl", NullValueHandling = NullValueHandling.Ignore)]
+        /// <summary>
+        /// The service URL.
+        /// </summary>
+        public string ServiceUrl { get; set; }
+        /// <summary>
+        /// The IAM authentication URL. If omitted the value defaults to "https://iam.bluemix.net/identity/token".
+        /// </summary>
         public string IamUrl { get; set; }
     }
 

--- a/src/IBM.WatsonDeveloperCloud/Util/TokenManager.cs
+++ b/src/IBM.WatsonDeveloperCloud/Util/TokenManager.cs
@@ -35,7 +35,7 @@ namespace IBM.WatsonDeveloperCloud.Util
 
         public TokenManager(TokenOptions options)
         {
-            _iamUrl = "https://iam.ng.bluemix.net/identity/token";
+            _iamUrl = !string.IsNullOrEmpty(options.IamUrl) ? options.IamUrl : "https://iam.bluemix.net/identity/token";
             _tokenInfo = new IamTokenData();
             if (!string.IsNullOrEmpty(options.IamApiKey))
                 _iamApikey = options.IamApiKey;

--- a/test/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests/VisualRecognitionServiceRCIntegrationTests.cs
+++ b/test/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests/VisualRecognitionServiceRCIntegrationTests.cs
@@ -91,7 +91,7 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests
             TokenOptions tokenOptions = new TokenOptions()
             {
                 IamApiKey = _apikey,
-                IamUrl = _endpoint
+                ServiceUrl = _endpoint
             };
             _service = new VisualRecognitionService(tokenOptions, "2018-03-19");
             _service.Client.BaseClient.Timeout = TimeSpan.FromMinutes(120);


### PR DESCRIPTION
### Summary

This pull request disambiguates the IamUrl and service url by adding a ServiceUrl to the options model Previously we were using the IamUrl field to set the service url and the true IamUrl was hard coded into the TokenManager. Now the IamUrl is user configurable and defaults to `https://iam.bluemix.net/identity/token`.