### PR TITLE
Removing the hardcoded endpoint. It causes other services other than …

### DIFF
--- a/src/IBM.WatsonDeveloperCloud/Service/WatsonService.cs
+++ b/src/IBM.WatsonDeveloperCloud/Service/WatsonService.cs
@@ -95,14 +95,11 @@ namespace IBM.WatsonDeveloperCloud.Service
 
         /// <summary>
         /// Sets the apikey of the service. 
-        /// Also sets the endpoint if the user has not set the endpoint.
         /// </summary>
         /// <param name="apikey"></param>
         public void SetCredential(string apikey)
         {
             this.ApiKey = apikey;
-            if (!_userSetEndpoint)
-                this.Endpoint = "https://gateway-a.watsonplatform.net/visual-recognition/api";
         }
 
         /// <summary>


### PR DESCRIPTION
…the one hardcoded to fail.

### Summary

When using the SetCredential method with the translator service, the hard coded point the api the worng endpoint.
