### PR TITLE
Move SetCredential(apikey)

### DIFF
--- a/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/IVisualRecognitionServiceExtension.cs
+++ b/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/IVisualRecognitionServiceExtension.cs
@@ -23,6 +23,8 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3
 {
     public partial interface IVisualRecognitionService
     {
+        void SetCredential(string apikey);
+
         Classifier CreateClassifier(CreateClassifier createClassifier, Dictionary<string, object> customData = null);
         
         Classifier UpdateClassifier(UpdateClassifier updateClassifier, Dictionary<string, object> customData = null);

--- a/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/VisualRecognitionServiceExtension.cs
+++ b/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/VisualRecognitionServiceExtension.cs
@@ -37,7 +37,7 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3
         /// Also sets the endpoint if the user has not set the endpoint.
         /// </summary>
         /// <param name="apikey"></param>
-        private void SetCredential(string apikey)
+        public void SetCredential(string apikey)
         {
             this.ApiKey = apikey;
             if (!_userSetEndpoint)

--- a/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/VisualRecognitionServiceExtension.cs
+++ b/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/VisualRecognitionServiceExtension.cs
@@ -33,6 +33,18 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3
     public partial class VisualRecognitionService : WatsonService, IVisualRecognitionService
     {
         /// <summary>
+        /// Sets the apikey of the service. 
+        /// Also sets the endpoint if the user has not set the endpoint.
+        /// </summary>
+        /// <param name="apikey"></param>
+        private void SetCredential(string apikey)
+        {
+            this.ApiKey = apikey;
+            if (!_userSetEndpoint)
+                this.Endpoint = "https://gateway-a.watsonplatform.net/visual-recognition/api";
+        }
+
+        /// <summary>
         /// Create a classifier. Train a new multi-faceted classifier on the uploaded image data. Create your custom classifier with positive or negative examples. Include at least two sets of examples, either two positive example files or one positive and one negative file. You can upload a maximum of 256 MB per call.  Encode all names in UTF-8 if they contain non-ASCII characters (.zip and image file names, and classifier and class names). The service assumes UTF-8 encoding if it encounters non-ASCII characters.
         /// </summary>
         /// <param name="createClassifier">Object used to define options for creating a classifier.</param>

--- a/src/IBM.WatsonDeveloperCloud/Service/IWatsonService.cs
+++ b/src/IBM.WatsonDeveloperCloud/Service/IWatsonService.cs
@@ -30,7 +30,6 @@ namespace IBM.WatsonDeveloperCloud.Service
         string Password { get; set; }
 
         void SetCredential(string userName, string password);
-        void SetCredential(string apikey);
         void SetCredential(TokenOptions tokenOptions);
         void SetEndpoint(string endpoint);
     }

--- a/src/IBM.WatsonDeveloperCloud/Service/WatsonService.cs
+++ b/src/IBM.WatsonDeveloperCloud/Service/WatsonService.cs
@@ -92,19 +92,7 @@ namespace IBM.WatsonDeveloperCloud.Service
             this.UserName = userName;
             this.Password = password;
         }
-
-        /// <summary>
-        /// Sets the apikey of the service. 
-        /// Also sets the endpoint if the user has not set the endpoint.
-        /// </summary>
-        /// <param name="apikey"></param>
-        public void SetCredential(string apikey)
-        {
-            this.ApiKey = apikey;
-            if (!_userSetEndpoint)
-                this.Endpoint = "https://gateway-a.watsonplatform.net/visual-recognition/api";
-        }
-
+        
         /// <summary>
         /// Sets the tokenOptions for the service. 
         /// Also sets the endpoint if the user has not set the endpoint.


### PR DESCRIPTION
### Summary
Fixes #248 

This pull request moves the SetCredential(apikey) method from the base service to the VisualRecognition extension. Users of other services were trying to authenticate using this method and IAM apikey. This will remove the confusion as they will not be able to SetCredential(apikey) from any service other than Visual Recognition. 