### PR TITLE
Discovery credentials unit tests

### DIFF
--- a/IBM.WatsonDeveloperCloud.sln
+++ b/IBM.WatsonDeveloperCloud.sln
@@ -113,11 +113,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "LanguageTranslatorV3", "Lan
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IBM.WatsonDeveloperCloud.LanguageTranslator.v3", "src\IBM.WatsonDeveloperCloud.LanguageTranslator.v3\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.csproj", "{CF4DDE0B-F484-49EB-A78B-10772AB458C2}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests", "test\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests.csproj", "{0A0E29F3-02D1-4824-A523-AC0EA962CB91}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example", "examples\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example.csproj", "{B71E13FA-0A6E-4B90-B509-6B2D690554C9}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests", "test\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests.csproj", "{A979FF0A-063D-4D96-A9B2-81E7A483E2AC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests", "test\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests.csproj", "{5DAAA089-EDCA-448F-835E-1EB1CAEB0226}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example", "examples\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example.csproj", "{E70682E0-EE89-4FEE-82F2-01ED0990E2E2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests", "test\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests.csproj", "{F1D7E642-0F19-497F-89E6-8D0FD747C595}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -281,18 +281,18 @@ Global
 		{CF4DDE0B-F484-49EB-A78B-10772AB458C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CF4DDE0B-F484-49EB-A78B-10772AB458C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CF4DDE0B-F484-49EB-A78B-10772AB458C2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0A0E29F3-02D1-4824-A523-AC0EA962CB91}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0A0E29F3-02D1-4824-A523-AC0EA962CB91}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0A0E29F3-02D1-4824-A523-AC0EA962CB91}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0A0E29F3-02D1-4824-A523-AC0EA962CB91}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A979FF0A-063D-4D96-A9B2-81E7A483E2AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A979FF0A-063D-4D96-A9B2-81E7A483E2AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A979FF0A-063D-4D96-A9B2-81E7A483E2AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A979FF0A-063D-4D96-A9B2-81E7A483E2AC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E70682E0-EE89-4FEE-82F2-01ED0990E2E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E70682E0-EE89-4FEE-82F2-01ED0990E2E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E70682E0-EE89-4FEE-82F2-01ED0990E2E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E70682E0-EE89-4FEE-82F2-01ED0990E2E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B71E13FA-0A6E-4B90-B509-6B2D690554C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B71E13FA-0A6E-4B90-B509-6B2D690554C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B71E13FA-0A6E-4B90-B509-6B2D690554C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B71E13FA-0A6E-4B90-B509-6B2D690554C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5DAAA089-EDCA-448F-835E-1EB1CAEB0226}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5DAAA089-EDCA-448F-835E-1EB1CAEB0226}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5DAAA089-EDCA-448F-835E-1EB1CAEB0226}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5DAAA089-EDCA-448F-835E-1EB1CAEB0226}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1D7E642-0F19-497F-89E6-8D0FD747C595}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1D7E642-0F19-497F-89E6-8D0FD747C595}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1D7E642-0F19-497F-89E6-8D0FD747C595}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1D7E642-0F19-497F-89E6-8D0FD747C595}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -351,9 +351,9 @@ Global
 		{7E050830-759C-4D12-BB8F-57DA8853616D} = {D65AC99F-4E63-4362-8765-EB6F15838CA0}
 		{65D78D49-E54F-4952-A1D4-7C8D0EDAA1B3} = {28E61676-E9FF-4DA9-99CC-5E0D16F02380}
 		{CF4DDE0B-F484-49EB-A78B-10772AB458C2} = {65D78D49-E54F-4952-A1D4-7C8D0EDAA1B3}
-		{0A0E29F3-02D1-4824-A523-AC0EA962CB91} = {65D78D49-E54F-4952-A1D4-7C8D0EDAA1B3}
-		{A979FF0A-063D-4D96-A9B2-81E7A483E2AC} = {65D78D49-E54F-4952-A1D4-7C8D0EDAA1B3}
-		{E70682E0-EE89-4FEE-82F2-01ED0990E2E2} = {65D78D49-E54F-4952-A1D4-7C8D0EDAA1B3}
+		{B71E13FA-0A6E-4B90-B509-6B2D690554C9} = {65D78D49-E54F-4952-A1D4-7C8D0EDAA1B3}
+		{5DAAA089-EDCA-448F-835E-1EB1CAEB0226} = {65D78D49-E54F-4952-A1D4-7C8D0EDAA1B3}
+		{F1D7E642-0F19-497F-89E6-8D0FD747C595} = {65D78D49-E54F-4952-A1D4-7C8D0EDAA1B3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B9D9D17B-1C17-402F-B701-DC671528690A}

--- a/test/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests/DiscoveryUnitTests.cs
+++ b/test/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests/DiscoveryUnitTests.cs
@@ -3762,5 +3762,510 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests
         }
         #endregion
         #endregion
+
+        #region Credentials
+        #region List Credentials
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void ListCredentials_No_EnvironmentId()
+        {
+            DiscoveryService service = new DiscoveryService("username", "password", "versionDate");
+            service.ListCredentials(null);
+        }
+
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void ListCredentials_No_VersionDate()
+        {
+            DiscoveryService service = new DiscoveryService("username", "password", "versionDate");
+            service.VersionDate = null;
+            service.ListCredentials("environmentId");
+        }
+
+        [TestMethod, ExpectedException(typeof(AggregateException))]
+        public void ListCredentials_Catch_Exception()
+        {
+            IClient client = CreateClient();
+
+            IRequest request = Substitute.For<IRequest>();
+            client.GetAsync(Arg.Any<string>())
+                 .Returns(x =>
+                 {
+                     throw new AggregateException(new ServiceResponseException(Substitute.For<IResponse>(),
+                                                                               Substitute.For<HttpResponseMessage>(HttpStatusCode.BadRequest),
+                                                                               string.Empty));
+                 });
+
+            DiscoveryService service = new DiscoveryService(client);
+            service.VersionDate = "2017-11-07";
+            service.ListCredentials("environmentId");
+        }
+
+        [TestMethod]
+        public void ListCredentials_Success()
+        {
+            IClient client = CreateClient();
+
+            IRequest request = Substitute.For<IRequest>();
+            client.GetAsync(Arg.Any<string>())
+                .Returns(request);
+
+            #region Response
+            var response = new CredentialsList()
+            {
+                Credentials = new List<Credentials>()
+                {
+                    new Credentials()
+                    {
+                        SourceType = Credentials.SourceTypeEnum.BOX,
+                        CredentialDetails = new CredentialDetails()
+                        {
+                            ClientId = "clientId",
+                            ClientSecret = "clientSecret",
+                            CredentialType = CredentialDetails.CredentialTypeEnum.OAUTH2,
+                            EnterpriseId = "enterpriseId",
+                            OrganizationUrl = "organizationUrl",
+                            Passphrase = "passphrase",
+                            Password = "password",
+                            PrivateKey = "privateKey",
+                            PublicKeyId = "publicKeyId",
+                            SiteCollectionPath = "siteCollectionPath",
+                            Url = "url",
+                            Username = "username"
+                        }
+                    }
+                }
+            };
+            #endregion
+
+            request.WithArgument(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(request);
+            request.As<CredentialsList>()
+                .Returns(Task.FromResult(response));
+
+            DiscoveryService service = new DiscoveryService(client);
+            service.VersionDate = "versionDate";
+
+            var result = service.ListCredentials("environmentId");
+
+            Assert.IsNotNull(result);
+            client.Received().GetAsync(Arg.Any<string>());
+            Assert.IsNotNull(result.Credentials);
+            Assert.IsNotNull(result.Credentials[0]);
+            Assert.IsTrue(result.Credentials[0].SourceType == Credentials.SourceTypeEnum.BOX);
+            Assert.IsNotNull(result.Credentials[0].CredentialDetails);
+            Assert.IsTrue(result.Credentials[0].CredentialDetails.ClientId == "clientId");
+            Assert.IsTrue(result.Credentials[0].CredentialDetails.ClientSecret == "clientSecret");
+            Assert.IsTrue(result.Credentials[0].CredentialDetails.CredentialType == CredentialDetails.CredentialTypeEnum.OAUTH2);
+            Assert.IsTrue(result.Credentials[0].CredentialDetails.EnterpriseId == "enterpriseId");
+            Assert.IsTrue(result.Credentials[0].CredentialDetails.OrganizationUrl == "organizationUrl");
+            Assert.IsTrue(result.Credentials[0].CredentialDetails.Passphrase == "passphrase");
+            Assert.IsTrue(result.Credentials[0].CredentialDetails.Password == "password");
+            Assert.IsTrue(result.Credentials[0].CredentialDetails.PrivateKey == "privateKey");
+            Assert.IsTrue(result.Credentials[0].CredentialDetails.PublicKeyId == "publicKeyId");
+            Assert.IsTrue(result.Credentials[0].CredentialDetails.SiteCollectionPath == "siteCollectionPath");
+            Assert.IsTrue(result.Credentials[0].CredentialDetails.Url == "url");
+            Assert.IsTrue(result.Credentials[0].CredentialDetails.Username == "username");
+        }
+        #endregion
+
+        #region Create Credentials
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void CreateCredentials_No_Environment()
+        {
+            DiscoveryService service = new DiscoveryService("username", "password", "versionDate");
+            service.CreateCredentials(null, new Credentials());
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void CreateCredentials_No_Credentials()
+        {
+            DiscoveryService service = new DiscoveryService("username", "password", "versionDate");
+            service.CreateCredentials("environmentId", null);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void CreateCredentials_No_VersionDate()
+        {
+            DiscoveryService service = new DiscoveryService("username", "password", "versionDate");
+            service.VersionDate = null;
+
+            service.CreateCredentials("environtmentId", new Credentials());
+        }
+
+        [TestMethod, ExpectedException(typeof(AggregateException))]
+        public void CreateCredentials_Catch_Exception()
+        {
+            IClient client = CreateClient();
+
+            IRequest request = Substitute.For<IRequest>();
+            client.PostAsync(Arg.Any<string>())
+                 .Returns(x =>
+                 {
+                     throw new AggregateException(new ServiceResponseException(Substitute.For<IResponse>(),
+                                                                               Substitute.For<HttpResponseMessage>(HttpStatusCode.BadRequest),
+                                                                               string.Empty));
+                 });
+
+            DiscoveryService service = new DiscoveryService(client);
+            service.VersionDate = "2017-11-07";
+
+            service.CreateCredentials("environmentId", new Credentials());
+        }
+
+        [TestMethod]
+        public void CreateCredentials_Success()
+        {
+            IClient client = CreateClient();
+
+            IRequest request = Substitute.For<IRequest>();
+            client.PostAsync(Arg.Any<string>())
+                .Returns(request);
+
+            #region Response
+            Credentials response = new Credentials()
+            {
+                SourceType = Credentials.SourceTypeEnum.BOX,
+                CredentialDetails = new CredentialDetails()
+                {
+                    ClientId = "clientId",
+                    ClientSecret = "clientSecret",
+                    CredentialType = CredentialDetails.CredentialTypeEnum.OAUTH2,
+                    EnterpriseId = "enterpriseId",
+                    OrganizationUrl = "organizationUrl",
+                    Passphrase = "passphrase",
+                    Password = "password",
+                    PrivateKey = "privateKey",
+                    PublicKeyId = "publicKeyId",
+                    SiteCollectionPath = "siteCollectionPath",
+                    Url = "url",
+                    Username = "username"
+                }
+            };
+            #endregion
+
+            request.WithArgument(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(request);
+            request.WithArgument(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(request);
+            request.WithBody<Credentials>(new Credentials())
+                .Returns(request);
+            request.As<Credentials>()
+                .Returns(Task.FromResult(response));
+
+            DiscoveryService service = new DiscoveryService(client);
+            service.VersionDate = "versionDate";
+
+            var result = service.CreateCredentials("environmentId", new Credentials());
+
+            Assert.IsNotNull(result);
+            client.Received().PostAsync(Arg.Any<string>());
+            Assert.IsTrue(result.SourceType == Credentials.SourceTypeEnum.BOX);
+            Assert.IsNotNull(result.CredentialDetails);
+            Assert.IsTrue(result.CredentialDetails.ClientId == "clientId");
+            Assert.IsTrue(result.CredentialDetails.ClientSecret == "clientSecret");
+            Assert.IsTrue(result.CredentialDetails.CredentialType == CredentialDetails.CredentialTypeEnum.OAUTH2);
+            Assert.IsTrue(result.CredentialDetails.EnterpriseId == "enterpriseId");
+            Assert.IsTrue(result.CredentialDetails.OrganizationUrl == "organizationUrl");
+            Assert.IsTrue(result.CredentialDetails.Passphrase == "passphrase");
+            Assert.IsTrue(result.CredentialDetails.Password == "password");
+            Assert.IsTrue(result.CredentialDetails.PrivateKey == "privateKey");
+            Assert.IsTrue(result.CredentialDetails.PublicKeyId == "publicKeyId");
+            Assert.IsTrue(result.CredentialDetails.SiteCollectionPath == "siteCollectionPath");
+            Assert.IsTrue(result.CredentialDetails.Url == "url");
+            Assert.IsTrue(result.CredentialDetails.Username == "username");
+        }
+        #endregion
+
+        #region Get Credential
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void GetCredentials_No_EnvironmentId()
+        {
+            DiscoveryService service = new DiscoveryService("username", "password", "versionDate");
+            service.GetCredentials(null, "credentialId");
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void GetCredentials_No_CredentialId()
+        {
+            DiscoveryService service = new DiscoveryService("username", "password", "versionDate");
+            service.GetCredentials("environmentId", null);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void GetCredentials_No_VersionDate()
+        {
+            DiscoveryService service = new DiscoveryService("username", "password", "versionDate");
+            service.VersionDate = null;
+            service.GetCredentials("environmentId", "credentialId");
+        }
+
+        [TestMethod, ExpectedException(typeof(AggregateException))]
+        public void GetCredentials_Catch_Exception()
+        {
+            IClient client = CreateClient();
+
+            IRequest request = Substitute.For<IRequest>();
+            client.GetAsync(Arg.Any<string>())
+                 .Returns(x =>
+                 {
+                     throw new AggregateException(new ServiceResponseException(Substitute.For<IResponse>(),
+                                                                               Substitute.For<HttpResponseMessage>(HttpStatusCode.BadRequest),
+                                                                               string.Empty));
+                 });
+
+            DiscoveryService service = new DiscoveryService(client);
+            service.VersionDate = "2017-11-07";
+            service.GetCredentials("environmentId", "credentialId");
+        }
+
+        [TestMethod]
+        public void GetCredentials_Success()
+        {
+            IClient client = CreateClient();
+
+            IRequest request = Substitute.For<IRequest>();
+            client.GetAsync(Arg.Any<string>())
+                .Returns(request);
+
+            #region Response
+            Credentials response = new Credentials()
+            {
+                SourceType = Credentials.SourceTypeEnum.BOX,
+                CredentialDetails = new CredentialDetails()
+                {
+                    ClientId = "clientId",
+                    ClientSecret = "clientSecret",
+                    CredentialType = CredentialDetails.CredentialTypeEnum.OAUTH2,
+                    EnterpriseId = "enterpriseId",
+                    OrganizationUrl = "organizationUrl",
+                    Passphrase = "passphrase",
+                    Password = "password",
+                    PrivateKey = "privateKey",
+                    PublicKeyId = "publicKeyId",
+                    SiteCollectionPath = "siteCollectionPath",
+                    Url = "url",
+                    Username = "username"
+                }
+            };
+            #endregion
+
+            request.WithArgument(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(request);
+            request.As<Credentials>()
+                .Returns(Task.FromResult(response));
+
+            DiscoveryService service = new DiscoveryService(client);
+            service.VersionDate = "versionDate";
+
+            var result = service.GetCredentials("environmentId", "credentailID");
+
+            Assert.IsNotNull(result);
+            client.Received().GetAsync(Arg.Any<string>());
+            Assert.IsTrue(result.SourceType == Credentials.SourceTypeEnum.BOX);
+            Assert.IsNotNull(result.CredentialDetails);
+            Assert.IsTrue(result.CredentialDetails.ClientId == "clientId");
+            Assert.IsTrue(result.CredentialDetails.ClientSecret == "clientSecret");
+            Assert.IsTrue(result.CredentialDetails.CredentialType == CredentialDetails.CredentialTypeEnum.OAUTH2);
+            Assert.IsTrue(result.CredentialDetails.EnterpriseId == "enterpriseId");
+            Assert.IsTrue(result.CredentialDetails.OrganizationUrl == "organizationUrl");
+            Assert.IsTrue(result.CredentialDetails.Passphrase == "passphrase");
+            Assert.IsTrue(result.CredentialDetails.Password == "password");
+            Assert.IsTrue(result.CredentialDetails.PrivateKey == "privateKey");
+            Assert.IsTrue(result.CredentialDetails.PublicKeyId == "publicKeyId");
+            Assert.IsTrue(result.CredentialDetails.SiteCollectionPath == "siteCollectionPath");
+            Assert.IsTrue(result.CredentialDetails.Url == "url");
+            Assert.IsTrue(result.CredentialDetails.Username == "username");
+        }
+        #endregion
+
+        #region Delete Credential
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void DeleteCredentials_No_EnvironmentId()
+        {
+            DiscoveryService service = new DiscoveryService("username", "password", "versionDate");
+            service.DeleteCredentials(null, "credentialId");
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void DeleteCredentials_No_CredentialId()
+        {
+            DiscoveryService service = new DiscoveryService("username", "password", "versionDate");
+            service.DeleteCredentials("environmentId", null);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void DeleteCredentials_No_VersionDate()
+        {
+            DiscoveryService service = new DiscoveryService("username", "password", "versionDate");
+            service.VersionDate = null;
+            service.DeleteCredentials("environmentId", "credentialId");
+        }
+
+        [TestMethod, ExpectedException(typeof(AggregateException))]
+        public void DeleteCredentials_Catch_Exception()
+        {
+            IClient client = CreateClient();
+
+            IRequest request = Substitute.For<IRequest>();
+            client.DeleteAsync(Arg.Any<string>())
+                 .Returns(x =>
+                 {
+                     throw new AggregateException(new ServiceResponseException(Substitute.For<IResponse>(),
+                                                                               Substitute.For<HttpResponseMessage>(HttpStatusCode.BadRequest),
+                                                                               string.Empty));
+                 });
+
+            DiscoveryService service = new DiscoveryService(client);
+            service.VersionDate = "2017-11-07";
+
+            service.DeleteCredentials("environmentId", "credentialId");
+        }
+
+        [TestMethod]
+        public void DeleteCredentials_Success()
+        {
+            IClient client = CreateClient();
+
+            IRequest request = Substitute.For<IRequest>();
+            client.DeleteAsync(Arg.Any<string>())
+                .Returns(request);
+
+            #region Response
+            DeleteCredentials response = new DeleteCredentials()
+            {
+                CredentialId = "credentialId",
+                Status = DeleteCredentials.StatusEnum.DELETED
+            };
+            #endregion
+
+            request.WithArgument(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(request);
+            request.As<DeleteCredentials>()
+                .Returns(Task.FromResult(response));
+
+            DiscoveryService service = new DiscoveryService(client);
+            service.VersionDate = "versionDate";
+
+            var result = service.DeleteCredentials("environmentId", "credentialId");
+
+            Assert.IsNotNull(result);
+            client.Received().DeleteAsync(Arg.Any<string>());
+            Assert.IsTrue(result.CredentialId == "credentialId");
+            Assert.IsTrue(result.Status == DeleteCredentials.StatusEnum.DELETED);
+        }
+        #endregion
+
+        #region Update Credentials
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void UpdateCredentials_No_EnvironmentId()
+        {
+            DiscoveryService service = new DiscoveryService("username", "password", "versionDate");
+            service.UpdateCredentials(null, "credentialId", new Credentials());
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void UpdateCredentials_No_CredentialId()
+        {
+            DiscoveryService service = new DiscoveryService("username", "password", "versionDate");
+            service.UpdateCredentials("environmentId", null, new Credentials());
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void UpdateCredentials_No_Body()
+        {
+            DiscoveryService service = new DiscoveryService("username", "password", "versionDate");
+            service.UpdateCredentials("environmentId", "credentialId", null);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void UpdateCredentials_No_VersionDate()
+        {
+            DiscoveryService service = new DiscoveryService("username", "password", "versionDate");
+            service.VersionDate = null;
+            service.UpdateCredentials("environmentId", "credentialId", new Credentials());
+        }
+
+        [TestMethod, ExpectedException(typeof(AggregateException))]
+        public void UpdateCredentials_Catch_Exception()
+        {
+            IClient client = CreateClient();
+
+            IRequest request = Substitute.For<IRequest>();
+            client.PutAsync(Arg.Any<string>())
+                 .Returns(x =>
+                 {
+                     throw new AggregateException(new ServiceResponseException(Substitute.For<IResponse>(),
+                                                                               Substitute.For<HttpResponseMessage>(HttpStatusCode.BadRequest),
+                                                                               string.Empty));
+                 });
+
+            DiscoveryService service = new DiscoveryService(client);
+            service.VersionDate = "2017-11-07";
+
+            service.UpdateCredentials("environmentId", "credentialId", new Credentials());
+        }
+
+        [TestMethod]
+        public void UpdateCredentials_Success()
+        {
+            IClient client = CreateClient();
+
+            IRequest request = Substitute.For<IRequest>();
+            client.PutAsync(Arg.Any<string>())
+                .Returns(request);
+
+            #region Response
+            Credentials response = new Credentials()
+            {
+                SourceType = Credentials.SourceTypeEnum.BOX,
+                CredentialDetails = new CredentialDetails()
+                {
+                    ClientId = "clientId",
+                    ClientSecret = "clientSecret",
+                    CredentialType = CredentialDetails.CredentialTypeEnum.OAUTH2,
+                    EnterpriseId = "enterpriseId",
+                    OrganizationUrl = "organizationUrl",
+                    Passphrase = "passphrase",
+                    Password = "password",
+                    PrivateKey = "privateKey",
+                    PublicKeyId = "publicKeyId",
+                    SiteCollectionPath = "siteCollectionPath",
+                    Url = "url",
+                    Username = "username"
+                }
+            };
+            #endregion
+
+            request.WithArgument(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(request);
+            request.WithBody<Credentials>(new Credentials())
+                .Returns(request);
+            request.As<Credentials>()
+                .Returns(Task.FromResult(response));
+
+            DiscoveryService service = new DiscoveryService(client);
+            service.VersionDate = "versionDate";
+
+            var result = service.UpdateCredentials("environmentId", "credentialId", new Credentials());
+
+            Assert.IsNotNull(result);
+            client.Received().PutAsync(Arg.Any<string>());
+            Assert.IsTrue(result.SourceType == Credentials.SourceTypeEnum.BOX);
+            Assert.IsNotNull(result.CredentialDetails);
+            Assert.IsTrue(result.CredentialDetails.ClientId == "clientId");
+            Assert.IsTrue(result.CredentialDetails.ClientSecret == "clientSecret");
+            Assert.IsTrue(result.CredentialDetails.CredentialType == CredentialDetails.CredentialTypeEnum.OAUTH2);
+            Assert.IsTrue(result.CredentialDetails.EnterpriseId == "enterpriseId");
+            Assert.IsTrue(result.CredentialDetails.OrganizationUrl == "organizationUrl");
+            Assert.IsTrue(result.CredentialDetails.Passphrase == "passphrase");
+            Assert.IsTrue(result.CredentialDetails.Password == "password");
+            Assert.IsTrue(result.CredentialDetails.PrivateKey == "privateKey");
+            Assert.IsTrue(result.CredentialDetails.PublicKeyId == "publicKeyId");
+            Assert.IsTrue(result.CredentialDetails.SiteCollectionPath == "siteCollectionPath");
+            Assert.IsTrue(result.CredentialDetails.Url == "url");
+            Assert.IsTrue(result.CredentialDetails.Username == "username");
+        }
+        #endregion
+        #endregion
     }
 }

--- a/test/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests/DiscoveryUnitTests.cs
+++ b/test/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests/DiscoveryUnitTests.cs
@@ -3060,18 +3060,18 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests
 
             Assert.IsNotNull(result);
             client.Received().GetAsync(Arg.Any<string>());
-            Assert.IsTrue(response.EnvironmentId == "environmentId");
-            Assert.IsTrue(response.CollectionId == "collectionId");
-            Assert.IsNotNull(response.Queries);
-            Assert.IsTrue(response.Queries.Count > 0);
-            Assert.IsTrue(response.Queries[0].QueryId == "queryId");
-            Assert.IsTrue(response.Queries[0].NaturalLanguageQuery == "naturalLanguageQuery");
-            Assert.IsTrue(response.Queries[0].Filter == "filter");
-            Assert.IsNotNull(response.Queries[0].Examples);
-            Assert.IsTrue(response.Queries[0].Examples.Count > 0);
-            Assert.IsTrue(response.Queries[0].Examples[0].DocumentId == "documentId");
-            Assert.IsTrue(response.Queries[0].Examples[0].CrossReference == "crossReference");
-            Assert.IsTrue(response.Queries[0].Examples[0].Relevance == 1.0f);
+            Assert.IsTrue(result.EnvironmentId == "environmentId");
+            Assert.IsTrue(result.CollectionId == "collectionId");
+            Assert.IsNotNull(result.Queries);
+            Assert.IsTrue(result.Queries.Count > 0);
+            Assert.IsTrue(result.Queries[0].QueryId == "queryId");
+            Assert.IsTrue(result.Queries[0].NaturalLanguageQuery == "naturalLanguageQuery");
+            Assert.IsTrue(result.Queries[0].Filter == "filter");
+            Assert.IsNotNull(result.Queries[0].Examples);
+            Assert.IsTrue(result.Queries[0].Examples.Count > 0);
+            Assert.IsTrue(result.Queries[0].Examples[0].DocumentId == "documentId");
+            Assert.IsTrue(result.Queries[0].Examples[0].CrossReference == "crossReference");
+            Assert.IsTrue(result.Queries[0].Examples[0].Relevance == 1.0f);
         }
         #endregion
 
@@ -3359,14 +3359,14 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests
 
             Assert.IsNotNull(result);
             client.Received().GetAsync(Arg.Any<string>());
-            Assert.IsTrue(response.QueryId == "queryId");
-            Assert.IsTrue(response.NaturalLanguageQuery == "naturalLanguageQuery");
-            Assert.IsTrue(response.Filter == "filter");
-            Assert.IsNotNull(response.Examples);
-            Assert.IsTrue(response.Examples.Count > 0);
-            Assert.IsTrue(response.Examples[0].DocumentId == "documentId");
-            Assert.IsTrue(response.Examples[0].CrossReference == "crossReference");
-            Assert.IsTrue(response.Examples[0].Relevance == 1.0f);
+            Assert.IsTrue(result.QueryId == "queryId");
+            Assert.IsTrue(result.NaturalLanguageQuery == "naturalLanguageQuery");
+            Assert.IsTrue(result.Filter == "filter");
+            Assert.IsNotNull(result.Examples);
+            Assert.IsTrue(result.Examples.Count > 0);
+            Assert.IsTrue(result.Examples[0].DocumentId == "documentId");
+            Assert.IsTrue(result.Examples[0].CrossReference == "crossReference");
+            Assert.IsTrue(result.Examples[0].Relevance == 1.0f);
         }
         #endregion
 
@@ -3400,7 +3400,7 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests
         public void CreateTrainingExample_No_Body()
         {
             DiscoveryService service = new DiscoveryService("username", "password", "versionDate");
-            service.CreateTrainingExample("environmentId", "collectionId", "queryId",null);
+            service.CreateTrainingExample("environmentId", "collectionId", "queryId", null);
         }
 
         [TestMethod, ExpectedException(typeof(ArgumentNullException))]
@@ -3648,9 +3648,9 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests
 
             Assert.IsNotNull(result);
             client.Received().GetAsync(Arg.Any<string>());
-            Assert.IsTrue(response.DocumentId == "documentId");
-            Assert.IsTrue(response.CrossReference == "crossReference");
-            Assert.IsTrue(response.Relevance == 1.0f);
+            Assert.IsTrue(result.DocumentId == "documentId");
+            Assert.IsTrue(result.CrossReference == "crossReference");
+            Assert.IsTrue(result.Relevance == 1.0f);
         }
         #endregion
 


### PR DESCRIPTION
### Summary
This pull request adds Discovery Credentials unit tests. Also, some unit tests were fixed to read from results instead of response. Finally, LTv3 tests and examples are now correctly named.