### PR TITLE
refactor(error-filter): simplify check for headers and content type

### DIFF
--- a/src/IBM.WatsonDeveloperCloud/Http/Filters/ErrorFilter.cs
+++ b/src/IBM.WatsonDeveloperCloud/Http/Filters/ErrorFilter.cs
@@ -34,7 +34,7 @@ namespace IBM.WatsonDeveloperCloud.Http.Filters
 
                 var error = responseMessage.Content.ReadAsStringAsync().Result;
 
-                if (responseMessage.Content.Headers.ContentType != null && responseMessage.Content.Headers.ContentType.MediaType == HttpMediaType.APPLICATION_JSON)
+                if (responseMessage.Content.Headers?.ContentType?.MediaType == HttpMediaType.APPLICATION_JSON)
                 {
                     exception.Error = JsonConvert.DeserializeObject<Error>(error);
                 }


### PR DESCRIPTION
### Summary
This pull request simplifies a check in the error filter. We use null conditional instead of directly checking if `ContentType` is not set in headers.