### PR TITLE
Overloading of the CreateJob to use Stream and refactoring same code

### DIFF
--- a/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/ISpeechToTextService.cs
+++ b/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/ISpeechToTextService.cs
@@ -18,6 +18,7 @@
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using IBM.WatsonDeveloperCloud.SpeechToText.v1.Model;
+using System.IO;
 
 namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 {
@@ -361,6 +362,165 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
         /// <param name="customData">Custom data object to pass data including custom request headers.</param>
         /// <returns><see cref="RecognitionJob" />RecognitionJob</returns>
         RecognitionJob CreateJob(byte[] audio, string contentType, string model = null, string callbackUrl = null, string events = null, string userToken = null, long? resultsTtl = null, string customizationId = null, string acousticCustomizationId = null, string baseModelVersion = null, double? customizationWeight = null, long? inactivityTimeout = null, List<string> keywords = null, float? keywordsThreshold = null, long? maxAlternatives = null, float? wordAlternativesThreshold = null, bool? wordConfidence = null, bool? timestamps = null, bool? profanityFilter = null, bool? smartFormatting = null, bool? speakerLabels = null, Dictionary<string, object> customData = null);
+        /// <summary>
+        /// Create a job.
+        ///
+        /// Creates a job for a new asynchronous recognition request. The job is owned by the user whose service
+        /// credentials are used to create it. How you learn the status and results of a job depends on the parameters
+        /// you include with the job creation request:
+        /// * By callback notification: Include the `callback_url` parameter to specify a URL to which the service is to
+        /// send callback notifications when the status of the job changes. Optionally, you can also include the
+        /// `events` and `user_token` parameters to subscribe to specific events and to specify a string that is to be
+        /// included with each notification for the job.
+        /// * By polling the service: Omit the `callback_url`, `events`, and `user_token` parameters. You must then use
+        /// the **Check jobs** or **Check a job** methods to check the status of the job, using the latter to retrieve
+        /// the results when the job is complete.
+        ///
+        /// The two approaches are not mutually exclusive. You can poll the service for job status or obtain results
+        /// from the service manually even if you include a callback URL. In both cases, you can include the
+        /// `results_ttl` parameter to specify how long the results are to remain available after the job is complete.
+        /// For detailed usage information about the two approaches, including callback notifications, see [Creating a
+        /// job](https://console.bluemix.net/docs/services/speech-to-text/async.html#create). Using the HTTPS **Check a
+        /// job** method to retrieve results is more secure than receiving them via callback notification over HTTP
+        /// because it provides confidentiality in addition to authentication and data integrity.
+        ///
+        /// The method supports the same basic parameters as other HTTP and WebSocket recognition requests. It also
+        /// supports the following parameters specific to the asynchronous interface:
+        /// * `callback_url`
+        /// * `events`
+        /// * `user_token`
+        /// * `results_ttl`
+        ///
+        /// The service imposes a data size limit of 100 MB. It automatically detects the endianness of the incoming
+        /// audio and, for audio that includes multiple channels, downmixes the audio to one-channel mono during
+        /// transcoding. (For the `audio/l16` format, you can specify the endianness.)
+        ///
+        /// ### Audio formats (content types)
+        ///
+        ///  Use the `Content-Type` parameter to specify the audio format (MIME type) of the audio:
+        /// * `audio/basic` (Use only with narrowband models.)
+        /// * `audio/flac`
+        /// * `audio/l16` (Specify the sampling rate (`rate`) and optionally the number of channels (`channels`) and
+        /// endianness (`endianness`) of the audio.)
+        /// * `audio/mp3`
+        /// * `audio/mpeg`
+        /// * `audio/mulaw` (Specify the sampling rate (`rate`) of the audio.)
+        /// * `audio/ogg` (The service automatically detects the codec of the input audio.)
+        /// * `audio/ogg;codecs=opus`
+        /// * `audio/ogg;codecs=vorbis`
+        /// * `audio/wav` (Provide audio with a maximum of nine channels.)
+        /// * `audio/webm` (The service automatically detects the codec of the input audio.)
+        /// * `audio/webm;codecs=opus`
+        /// * `audio/webm;codecs=vorbis`
+        ///
+        /// For information about the supported audio formats, including specifying the sampling rate, channels, and
+        /// endianness for the indicated formats, see [Audio
+        /// formats](https://console.bluemix.net/docs/services/speech-to-text/audio-formats.html).
+        /// </summary>
+        /// <param name="audio">The audio stream to transcribe in the format specified by the `Content-Type` header.</param>
+        /// <param name="contentType">The type of the input.</param>
+        /// <param name="model">The identifier of the model that is to be used for the recognition request or, for the
+        /// **Create a session** method, with the new session. (optional, default to en-US_BroadbandModel)</param>
+        /// <param name="callbackUrl">A URL to which callback notifications are to be sent. The URL must already be
+        /// successfully white-listed by using the **Register a callback** method. You can include the same callback URL
+        /// with any number of job creation requests. Omit the parameter to poll the service for job completion and
+        /// results.
+        ///
+        /// Use the `user_token` parameter to specify a unique user-specified string with each job to differentiate the
+        /// callback notifications for the jobs. (optional)</param>
+        /// <param name="events">If the job includes a callback URL, a comma-separated list of notification events to
+        /// which to subscribe. Valid events are
+        /// * `recognitions.started` generates a callback notification when the service begins to process the job.
+        /// * `recognitions.completed` generates a callback notification when the job is complete. You must use the
+        /// **Check a job** method to retrieve the results before they time out or are deleted.
+        /// * `recognitions.completed_with_results` generates a callback notification when the job is complete. The
+        /// notification includes the results of the request.
+        /// * `recognitions.failed` generates a callback notification if the service experiences an error while
+        /// processing the job.
+        ///
+        /// Omit the parameter to subscribe to the default events: `recognitions.started`, `recognitions.completed`, and
+        /// `recognitions.failed`. The `recognitions.completed` and `recognitions.completed_with_results` events are
+        /// incompatible; you can specify only of the two events. If the job does not include a callback URL, omit the
+        /// parameter. (optional)</param>
+        /// <param name="userToken">If the job includes a callback URL, a user-specified string that the service is to
+        /// include with each callback notification for the job; the token allows the user to maintain an internal
+        /// mapping between jobs and notification events. If the job does not include a callback URL, omit the
+        /// parameter. (optional)</param>
+        /// <param name="resultsTtl">The number of minutes for which the results are to be available after the job has
+        /// finished. If not delivered via a callback, the results must be retrieved within this time. Omit the
+        /// parameter to use a time to live of one week. The parameter is valid with or without a callback URL.
+        /// (optional)</param>
+        /// <param name="customizationId">The customization ID (GUID) of a custom language model that is to be used with
+        /// the recognition request or, for the **Create a session** method, with the new session. The base model of the
+        /// specified custom language model must match the model specified with the `model` parameter. You must make the
+        /// request with service credentials created for the instance of the service that owns the custom model. By
+        /// default, no custom language model is used. (optional)</param>
+        /// <param name="acousticCustomizationId">The customization ID (GUID) of a custom acoustic model that is to be
+        /// used with the recognition request or, for the **Create a session** method, with the new session. The base
+        /// model of the specified custom acoustic model must match the model specified with the `model` parameter. You
+        /// must make the request with service credentials created for the instance of the service that owns the custom
+        /// model. By default, no custom acoustic model is used. (optional)</param>
+        /// <param name="baseModelVersion">The version of the specified base model that is to be used with recognition
+        /// request or, for the **Create a session** method, with the new session. Multiple versions of a base model can
+        /// exist when a model is updated for internal improvements. The parameter is intended primarily for use with
+        /// custom models that have been upgraded for a new base model. The default value depends on whether the
+        /// parameter is used with or without a custom model. For more information, see [Base model
+        /// version](https://console.bluemix.net/docs/services/speech-to-text/input.html#version). (optional)</param>
+        /// <param name="customizationWeight">If you specify the customization ID (GUID) of a custom language model with
+        /// the recognition request or, for sessions, with the **Create a session** method, the customization weight
+        /// tells the service how much weight to give to words from the custom language model compared to those from the
+        /// base model for the current request.
+        ///
+        /// Specify a value between 0.0 and 1.0. Unless a different customization weight was specified for the custom
+        /// model when it was trained, the default value is 0.3. A customization weight that you specify overrides a
+        /// weight that was specified when the custom model was trained.
+        ///
+        /// The default value yields the best performance in general. Assign a higher value if your audio makes frequent
+        /// use of OOV words from the custom model. Use caution when setting the weight: a higher value can improve the
+        /// accuracy of phrases from the custom model's domain, but it can negatively affect performance on non-domain
+        /// phrases. (optional)</param>
+        /// <param name="inactivityTimeout">The time in seconds after which, if only silence (no speech) is detected in
+        /// submitted audio, the connection is closed with a 400 error. The parameter is useful for stopping audio
+        /// submission from a live microphone when a user simply walks away. Use `-1` for infinity. (optional, default
+        /// to 30)</param>
+        /// <param name="keywords">An array of keyword strings to spot in the audio. Each keyword string can include one
+        /// or more tokens. Keywords are spotted only in the final results, not in interim hypotheses. If you specify
+        /// any keywords, you must also specify a keywords threshold. You can spot a maximum of 1000 keywords. Omit the
+        /// parameter or specify an empty array if you do not need to spot keywords. (optional)</param>
+        /// <param name="keywordsThreshold">A confidence value that is the lower bound for spotting a keyword. A word is
+        /// considered to match a keyword if its confidence is greater than or equal to the threshold. Specify a
+        /// probability between 0 and 1 inclusive. No keyword spotting is performed if you omit the parameter. If you
+        /// specify a threshold, you must also specify one or more keywords. (optional)</param>
+        /// <param name="maxAlternatives">The maximum number of alternative transcripts to be returned. By default, a
+        /// single transcription is returned. (optional, default to 1)</param>
+        /// <param name="wordAlternativesThreshold">A confidence value that is the lower bound for identifying a
+        /// hypothesis as a possible word alternative (also known as "Confusion Networks"). An alternative word is
+        /// considered if its confidence is greater than or equal to the threshold. Specify a probability between 0 and
+        /// 1 inclusive. No alternative words are computed if you omit the parameter. (optional)</param>
+        /// <param name="wordConfidence">If `true`, a confidence measure in the range of 0 to 1 is returned for each
+        /// word. By default, no word confidence measures are returned. (optional, default to false)</param>
+        /// <param name="timestamps">If `true`, time alignment is returned for each word. By default, no timestamps are
+        /// returned. (optional, default to false)</param>
+        /// <param name="profanityFilter">If `true` (the default), filters profanity from all output except for keyword
+        /// results by replacing inappropriate words with a series of asterisks. Set the parameter to `false` to return
+        /// results with no censoring. Applies to US English transcription only. (optional, default to true)</param>
+        /// <param name="smartFormatting">If `true`, converts dates, times, series of digits and numbers, phone numbers,
+        /// currency values, and internet addresses into more readable, conventional representations in the final
+        /// transcript of a recognition request. For US English, also converts certain keyword strings to punctuation
+        /// symbols. By default, no smart formatting is performed. Applies to US English and Spanish transcription only.
+        /// (optional, default to false)</param>
+        /// <param name="speakerLabels">If `true`, the response includes labels that identify which words were spoken by
+        /// which participants in a multi-person exchange. By default, no speaker labels are returned. Setting
+        /// `speaker_labels` to `true` forces the `timestamps` parameter to be `true`, regardless of whether you specify
+        /// `false` for the parameter.
+        ///
+        ///  To determine whether a language model supports speaker labels, use the **Get models** method and check that
+        /// the attribute `speaker_labels` is set to `true`. You can also refer to [Speaker
+        /// labels](https://console.bluemix.net/docs/services/speech-to-text/output.html#speaker_labels). (optional,
+        /// default to false)</param>
+        /// <param name="customData">Custom data object to pass data including custom request headers.</param>
+        /// <returns><see cref="RecognitionJob" />RecognitionJob</returns>
+        RecognitionJob CreateJob(Stream audio, string contentType, string model = null, string callbackUrl = null, string events = null, string userToken = null, long? resultsTtl = null, string customizationId = null, string acousticCustomizationId = null, string baseModelVersion = null, double? customizationWeight = null, long? inactivityTimeout = null, List<string> keywords = null, float? keywordsThreshold = null, long? maxAlternatives = null, float? wordAlternativesThreshold = null, bool? wordConfidence = null, bool? timestamps = null, bool? profanityFilter = null, bool? smartFormatting = null, bool? speakerLabels = null, Dictionary<string, object> customData = null);
         /// <summary>
         /// Delete a job.
         ///

--- a/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/SpeechToTextService.cs
+++ b/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/SpeechToTextService.cs
@@ -615,55 +615,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
             try
             {
-                IClient client;
-                if(_tokenManager == null)
-                {
-                    client = this.Client.WithAuthentication(this.UserName, this.Password);
-                }
-                else
-                {
-                    client = this.Client.WithAuthentication(_tokenManager.GetToken());
-                }
-                var restRequest = client.PostAsync($"{this.Endpoint}/v1/recognitions");
+                IRequest restRequest = GetCreateJobRequest(contentType, model, callbackUrl, events, userToken, resultsTtl, customizationId, acousticCustomizationId, baseModelVersion, customizationWeight, inactivityTimeout, keywords, keywordsThreshold, maxAlternatives, wordAlternativesThreshold, wordConfidence, timestamps, profanityFilter, smartFormatting, speakerLabels);
 
-                restRequest.WithHeader("Content-Type", contentType);
-                if (!string.IsNullOrEmpty(model))
-                    restRequest.WithArgument("model", model);
-                if (!string.IsNullOrEmpty(callbackUrl))
-                    restRequest.WithArgument("callback_url", callbackUrl);
-                if (!string.IsNullOrEmpty(events))
-                    restRequest.WithArgument("events", events);
-                if (!string.IsNullOrEmpty(userToken))
-                    restRequest.WithArgument("user_token", userToken);
-                if (resultsTtl != null)
-                    restRequest.WithArgument("results_ttl", resultsTtl);
-                if (!string.IsNullOrEmpty(customizationId))
-                    restRequest.WithArgument("customization_id", customizationId);
-                if (!string.IsNullOrEmpty(acousticCustomizationId))
-                    restRequest.WithArgument("acoustic_customization_id", acousticCustomizationId);
-                if (!string.IsNullOrEmpty(baseModelVersion))
-                    restRequest.WithArgument("base_model_version", baseModelVersion);
-                if (customizationWeight != null)
-                    restRequest.WithArgument("customization_weight", customizationWeight);
-                if (inactivityTimeout != null)
-                    restRequest.WithArgument("inactivity_timeout", inactivityTimeout);
-                restRequest.WithArgument("keywords", keywords != null && keywords.Count > 0 ? string.Join(",", keywords.ToArray()) : null);
-                if (keywordsThreshold != null)
-                    restRequest.WithArgument("keywords_threshold", keywordsThreshold);
-                if (maxAlternatives != null)
-                    restRequest.WithArgument("max_alternatives", maxAlternatives);
-                if (wordAlternativesThreshold != null)
-                    restRequest.WithArgument("word_alternatives_threshold", wordAlternativesThreshold);
-                if (wordConfidence != null)
-                    restRequest.WithArgument("word_confidence", wordConfidence);
-                if (timestamps != null)
-                    restRequest.WithArgument("timestamps", timestamps);
-                if (profanityFilter != null)
-                    restRequest.WithArgument("profanity_filter", profanityFilter);
-                if (smartFormatting != null)
-                    restRequest.WithArgument("smart_formatting", smartFormatting);
-                if (speakerLabels != null)
-                    restRequest.WithArgument("speaker_labels", speakerLabels);
                 restRequest.WithBody<byte[]>(audio);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
@@ -678,6 +631,251 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Create a job.
+        ///
+        /// Creates a job for a new asynchronous recognition request. The job is owned by the user whose service
+        /// credentials are used to create it. How you learn the status and results of a job depends on the parameters
+        /// you include with the job creation request:
+        /// * By callback notification: Include the `callback_url` parameter to specify a URL to which the service is to
+        /// send callback notifications when the status of the job changes. Optionally, you can also include the
+        /// `events` and `user_token` parameters to subscribe to specific events and to specify a string that is to be
+        /// included with each notification for the job.
+        /// * By polling the service: Omit the `callback_url`, `events`, and `user_token` parameters. You must then use
+        /// the **Check jobs** or **Check a job** methods to check the status of the job, using the latter to retrieve
+        /// the results when the job is complete.
+        ///
+        /// The two approaches are not mutually exclusive. You can poll the service for job status or obtain results
+        /// from the service manually even if you include a callback URL. In both cases, you can include the
+        /// `results_ttl` parameter to specify how long the results are to remain available after the job is complete.
+        /// For detailed usage information about the two approaches, including callback notifications, see [Creating a
+        /// job](https://console.bluemix.net/docs/services/speech-to-text/async.html#create). Using the HTTPS **Check a
+        /// job** method to retrieve results is more secure than receiving them via callback notification over HTTP
+        /// because it provides confidentiality in addition to authentication and data integrity.
+        ///
+        /// The method supports the same basic parameters as other HTTP and WebSocket recognition requests. It also
+        /// supports the following parameters specific to the asynchronous interface:
+        /// * `callback_url`
+        /// * `events`
+        /// * `user_token`
+        /// * `results_ttl`
+        ///
+        /// The service imposes a data size limit of 100 MB. It automatically detects the endianness of the incoming
+        /// audio and, for audio that includes multiple channels, downmixes the audio to one-channel mono during
+        /// transcoding. (For the `audio/l16` format, you can specify the endianness.)
+        ///
+        /// ### Audio formats (content types)
+        ///
+        ///  Use the `Content-Type` parameter to specify the audio format (MIME type) of the audio:
+        /// * `audio/basic` (Use only with narrowband models.)
+        /// * `audio/flac`
+        /// * `audio/l16` (Specify the sampling rate (`rate`) and optionally the number of channels (`channels`) and
+        /// endianness (`endianness`) of the audio.)
+        /// * `audio/mp3`
+        /// * `audio/mpeg`
+        /// * `audio/mulaw` (Specify the sampling rate (`rate`) of the audio.)
+        /// * `audio/ogg` (The service automatically detects the codec of the input audio.)
+        /// * `audio/ogg;codecs=opus`
+        /// * `audio/ogg;codecs=vorbis`
+        /// * `audio/wav` (Provide audio with a maximum of nine channels.)
+        /// * `audio/webm` (The service automatically detects the codec of the input audio.)
+        /// * `audio/webm;codecs=opus`
+        /// * `audio/webm;codecs=vorbis`
+        ///
+        /// For information about the supported audio formats, including specifying the sampling rate, channels, and
+        /// endianness for the indicated formats, see [Audio
+        /// formats](https://console.bluemix.net/docs/services/speech-to-text/audio-formats.html).
+        /// </summary>
+        /// <param name="audio">The audio stream to transcribe in the format specified by the `Content-Type` header.</param>
+        /// <param name="contentType">The type of the input.</param>
+        /// <param name="model">The identifier of the model that is to be used for the recognition request or, for the
+        /// **Create a session** method, with the new session. (optional, default to en-US_BroadbandModel)</param>
+        /// <param name="callbackUrl">A URL to which callback notifications are to be sent. The URL must already be
+        /// successfully white-listed by using the **Register a callback** method. You can include the same callback URL
+        /// with any number of job creation requests. Omit the parameter to poll the service for job completion and
+        /// results.
+        ///
+        /// Use the `user_token` parameter to specify a unique user-specified string with each job to differentiate the
+        /// callback notifications for the jobs. (optional)</param>
+        /// <param name="events">If the job includes a callback URL, a comma-separated list of notification events to
+        /// which to subscribe. Valid events are
+        /// * `recognitions.started` generates a callback notification when the service begins to process the job.
+        /// * `recognitions.completed` generates a callback notification when the job is complete. You must use the
+        /// **Check a job** method to retrieve the results before they time out or are deleted.
+        /// * `recognitions.completed_with_results` generates a callback notification when the job is complete. The
+        /// notification includes the results of the request.
+        /// * `recognitions.failed` generates a callback notification if the service experiences an error while
+        /// processing the job.
+        ///
+        /// Omit the parameter to subscribe to the default events: `recognitions.started`, `recognitions.completed`, and
+        /// `recognitions.failed`. The `recognitions.completed` and `recognitions.completed_with_results` events are
+        /// incompatible; you can specify only of the two events. If the job does not include a callback URL, omit the
+        /// parameter. (optional)</param>
+        /// <param name="userToken">If the job includes a callback URL, a user-specified string that the service is to
+        /// include with each callback notification for the job; the token allows the user to maintain an internal
+        /// mapping between jobs and notification events. If the job does not include a callback URL, omit the
+        /// parameter. (optional)</param>
+        /// <param name="resultsTtl">The number of minutes for which the results are to be available after the job has
+        /// finished. If not delivered via a callback, the results must be retrieved within this time. Omit the
+        /// parameter to use a time to live of one week. The parameter is valid with or without a callback URL.
+        /// (optional)</param>
+        /// <param name="customizationId">The customization ID (GUID) of a custom language model that is to be used with
+        /// the recognition request or, for the **Create a session** method, with the new session. The base model of the
+        /// specified custom language model must match the model specified with the `model` parameter. You must make the
+        /// request with service credentials created for the instance of the service that owns the custom model. By
+        /// default, no custom language model is used. (optional)</param>
+        /// <param name="acousticCustomizationId">The customization ID (GUID) of a custom acoustic model that is to be
+        /// used with the recognition request or, for the **Create a session** method, with the new session. The base
+        /// model of the specified custom acoustic model must match the model specified with the `model` parameter. You
+        /// must make the request with service credentials created for the instance of the service that owns the custom
+        /// model. By default, no custom acoustic model is used. (optional)</param>
+        /// <param name="baseModelVersion">The version of the specified base model that is to be used with recognition
+        /// request or, for the **Create a session** method, with the new session. Multiple versions of a base model can
+        /// exist when a model is updated for internal improvements. The parameter is intended primarily for use with
+        /// custom models that have been upgraded for a new base model. The default value depends on whether the
+        /// parameter is used with or without a custom model. For more information, see [Base model
+        /// version](https://console.bluemix.net/docs/services/speech-to-text/input.html#version). (optional)</param>
+        /// <param name="customizationWeight">If you specify the customization ID (GUID) of a custom language model with
+        /// the recognition request or, for sessions, with the **Create a session** method, the customization weight
+        /// tells the service how much weight to give to words from the custom language model compared to those from the
+        /// base model for the current request.
+        ///
+        /// Specify a value between 0.0 and 1.0. Unless a different customization weight was specified for the custom
+        /// model when it was trained, the default value is 0.3. A customization weight that you specify overrides a
+        /// weight that was specified when the custom model was trained.
+        ///
+        /// The default value yields the best performance in general. Assign a higher value if your audio makes frequent
+        /// use of OOV words from the custom model. Use caution when setting the weight: a higher value can improve the
+        /// accuracy of phrases from the custom model's domain, but it can negatively affect performance on non-domain
+        /// phrases. (optional)</param>
+        /// <param name="inactivityTimeout">The time in seconds after which, if only silence (no speech) is detected in
+        /// submitted audio, the connection is closed with a 400 error. The parameter is useful for stopping audio
+        /// submission from a live microphone when a user simply walks away. Use `-1` for infinity. (optional, default
+        /// to 30)</param>
+        /// <param name="keywords">An array of keyword strings to spot in the audio. Each keyword string can include one
+        /// or more tokens. Keywords are spotted only in the final results, not in interim hypotheses. If you specify
+        /// any keywords, you must also specify a keywords threshold. You can spot a maximum of 1000 keywords. Omit the
+        /// parameter or specify an empty array if you do not need to spot keywords. (optional)</param>
+        /// <param name="keywordsThreshold">A confidence value that is the lower bound for spotting a keyword. A word is
+        /// considered to match a keyword if its confidence is greater than or equal to the threshold. Specify a
+        /// probability between 0 and 1 inclusive. No keyword spotting is performed if you omit the parameter. If you
+        /// specify a threshold, you must also specify one or more keywords. (optional)</param>
+        /// <param name="maxAlternatives">The maximum number of alternative transcripts to be returned. By default, a
+        /// single transcription is returned. (optional, default to 1)</param>
+        /// <param name="wordAlternativesThreshold">A confidence value that is the lower bound for identifying a
+        /// hypothesis as a possible word alternative (also known as "Confusion Networks"). An alternative word is
+        /// considered if its confidence is greater than or equal to the threshold. Specify a probability between 0 and
+        /// 1 inclusive. No alternative words are computed if you omit the parameter. (optional)</param>
+        /// <param name="wordConfidence">If `true`, a confidence measure in the range of 0 to 1 is returned for each
+        /// word. By default, no word confidence measures are returned. (optional, default to false)</param>
+        /// <param name="timestamps">If `true`, time alignment is returned for each word. By default, no timestamps are
+        /// returned. (optional, default to false)</param>
+        /// <param name="profanityFilter">If `true` (the default), filters profanity from all output except for keyword
+        /// results by replacing inappropriate words with a series of asterisks. Set the parameter to `false` to return
+        /// results with no censoring. Applies to US English transcription only. (optional, default to true)</param>
+        /// <param name="smartFormatting">If `true`, converts dates, times, series of digits and numbers, phone numbers,
+        /// currency values, and internet addresses into more readable, conventional representations in the final
+        /// transcript of a recognition request. For US English, also converts certain keyword strings to punctuation
+        /// symbols. By default, no smart formatting is performed. Applies to US English and Spanish transcription only.
+        /// (optional, default to false)</param>
+        /// <param name="speakerLabels">If `true`, the response includes labels that identify which words were spoken by
+        /// which participants in a multi-person exchange. By default, no speaker labels are returned. Setting
+        /// `speaker_labels` to `true` forces the `timestamps` parameter to be `true`, regardless of whether you specify
+        /// `false` for the parameter.
+        ///
+        ///  To determine whether a language model supports speaker labels, use the **Get models** method and check that
+        /// the attribute `speaker_labels` is set to `true`. You can also refer to [Speaker
+        /// labels](https://console.bluemix.net/docs/services/speech-to-text/output.html#speaker_labels). (optional,
+        /// default to false)</param>
+        /// <param name="customData">Custom data object to pass data including custom request headers.</param>
+        /// <returns><see cref="RecognitionJob" />RecognitionJob</returns>
+        public RecognitionJob CreateJob(Stream audio, string contentType, string model = null, string callbackUrl = null, string events = null, string userToken = null, long? resultsTtl = null, string customizationId = null, string acousticCustomizationId = null, string baseModelVersion = null, double? customizationWeight = null, long? inactivityTimeout = null, List<string> keywords = null, float? keywordsThreshold = null, long? maxAlternatives = null, float? wordAlternativesThreshold = null, bool? wordConfidence = null, bool? timestamps = null, bool? profanityFilter = null, bool? smartFormatting = null, bool? speakerLabels = null, Dictionary<string, object> customData = null)
+        {
+            if (audio == null)
+                throw new ArgumentNullException(nameof(audio));
+            if (string.IsNullOrEmpty(contentType))
+                throw new ArgumentNullException(nameof(contentType));
+            RecognitionJob result = null;
+
+            try
+            {
+                IRequest restRequest = GetCreateJobRequest(contentType, model, callbackUrl, events, userToken, resultsTtl, customizationId, acousticCustomizationId, baseModelVersion, customizationWeight, inactivityTimeout, keywords, keywordsThreshold, maxAlternatives, wordAlternativesThreshold, wordConfidence, timestamps, profanityFilter, smartFormatting, speakerLabels);
+
+                StreamContent content = new StreamContent(audio);
+                restRequest.WithBodyContent(content);
+                restRequest.WithContentType(contentType);
+
+                if (customData != null)
+                    restRequest.WithCustomData(customData);
+                result = restRequest.As<RecognitionJob>().Result;
+                if (result == null)
+                    result = new RecognitionJob();
+                result.CustomData = restRequest.CustomData;
+            }
+            catch (AggregateException ae)
+            {
+                throw ae.Flatten();
+            }
+
+            return result;
+        }
+
+        private IRequest GetCreateJobRequest(string contentType, string model, string callbackUrl, string events, string userToken, long? resultsTtl, string customizationId, string acousticCustomizationId, string baseModelVersion, double? customizationWeight, long? inactivityTimeout, List<string> keywords, float? keywordsThreshold, long? maxAlternatives, float? wordAlternativesThreshold, bool? wordConfidence, bool? timestamps, bool? profanityFilter, bool? smartFormatting, bool? speakerLabels)
+        {
+            IClient client;
+            if (_tokenManager == null)
+            {
+                client = this.Client.WithAuthentication(this.UserName, this.Password);
+            }
+            else
+            {
+                client = this.Client.WithAuthentication(_tokenManager.GetToken());
+            }
+            var restRequest = client.PostAsync($"{this.Endpoint}/v1/recognitions");
+
+            restRequest.WithHeader("Content-Type", contentType);
+
+            if (!string.IsNullOrEmpty(model))
+                restRequest.WithArgument("model", model);
+            if (!string.IsNullOrEmpty(callbackUrl))
+                restRequest.WithArgument("callback_url", callbackUrl);
+            if (!string.IsNullOrEmpty(events))
+                restRequest.WithArgument("events", events);
+            if (!string.IsNullOrEmpty(userToken))
+                restRequest.WithArgument("user_token", userToken);
+            if (resultsTtl != null)
+                restRequest.WithArgument("results_ttl", resultsTtl);
+            if (!string.IsNullOrEmpty(customizationId))
+                restRequest.WithArgument("customization_id", customizationId);
+            if (!string.IsNullOrEmpty(acousticCustomizationId))
+                restRequest.WithArgument("acoustic_customization_id", acousticCustomizationId);
+            if (!string.IsNullOrEmpty(baseModelVersion))
+                restRequest.WithArgument("base_model_version", baseModelVersion);
+            if (customizationWeight != null)
+                restRequest.WithArgument("customization_weight", customizationWeight);
+            if (inactivityTimeout != null)
+                restRequest.WithArgument("inactivity_timeout", inactivityTimeout);
+            if (keywords != null && keywords.Count > 0)
+                restRequest.WithArgument("keywords", string.Join(",", keywords.ToArray()));
+            if (keywordsThreshold != null)
+                restRequest.WithArgument("keywords_threshold", keywordsThreshold);
+            if (maxAlternatives != null)
+                restRequest.WithArgument("max_alternatives", maxAlternatives);
+            if (wordAlternativesThreshold != null)
+                restRequest.WithArgument("word_alternatives_threshold", wordAlternativesThreshold);
+            if (wordConfidence != null)
+                restRequest.WithArgument("word_confidence", wordConfidence);
+            if (timestamps != null)
+                restRequest.WithArgument("timestamps", timestamps);
+            if (profanityFilter != null)
+                restRequest.WithArgument("profanity_filter", profanityFilter);
+            if (smartFormatting != null)
+                restRequest.WithArgument("smart_formatting", smartFormatting);
+            if (speakerLabels != null)
+                restRequest.WithArgument("speaker_labels", speakerLabels);
+            return restRequest;
         }
 
         /// <summary>

--- a/src/IBM.WatsonDeveloperCloud/Http/IRequest.cs
+++ b/src/IBM.WatsonDeveloperCloud/Http/IRequest.cs
@@ -38,6 +38,8 @@ namespace IBM.WatsonDeveloperCloud.Http
 
         IRequest WithHeader(string key, string value);
 
+        IRequest WithContentType(string contentType);
+
         IRequest WithArgument(string key, object value);
 
         IRequest WithArguments(object arguments);

--- a/src/IBM.WatsonDeveloperCloud/Http/Request.cs
+++ b/src/IBM.WatsonDeveloperCloud/Http/Request.cs
@@ -85,6 +85,12 @@ namespace IBM.WatsonDeveloperCloud.Http
             return this;
         }
 
+        public IRequest WithContentType(string contentType)
+        {
+            this.Message.Content.Headers.ContentType = new MediaTypeWithQualityHeaderValue(contentType);
+            return this;
+        }
+
         public IRequest WithArgument(string key, object value)
         {
             this.Message.RequestUri = this.Message.RequestUri.WithArguments(new KeyValuePair<string, object>(key, value));


### PR DESCRIPTION
### Summary

There is a new overload for the CreateJob method to pass a Stream instead of using the default byte array. This is helpful when We are using streams from remote audio storages and We do not use local files. Adittionaly I fixed the content-type header for this new overload, I added this header to the content. I made some refactor code because these overload methods share similar code to create the request and set the parameters. 

### Other Information

I commented that with @mediumTaj about this overload in this thread:
https://github.com/watson-developer-cloud/dotnet-standard-sdk/issues/249


Thanks for contributing to the Watson Developer Cloud!