### PR TITLE
Update acoustic resource

### DIFF
--- a/examples/IBM.WatsonDeveloperCloud.SpeechToText.v1.Example/SpeechToTextServiceExample.cs
+++ b/examples/IBM.WatsonDeveloperCloud.SpeechToText.v1.Example/SpeechToTextServiceExample.cs
@@ -39,7 +39,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1.Example
         //private string _corpusPath = @"SpeechToTextTestData/theJabberwocky-utf8.txt";
         private string _acousticModelName = "dotnet-integration-test-custom-acoustic-model";
         private string _acousticModelDescription = "A custom model to teset .NET SDK Speech to Text acoustic customization.";
-        private string _acousticResourceUrl = "https://ia802302.us.archive.org/10/items/Greatest_Speeches_of_the_20th_Century/TheFirstAmericaninEarthOrbit.mp3";
+        private string _acousticResourceUrl = "https://archive.org/download/Greatest_Speeches_of_the_20th_Century/KeynoteAddressforDemocraticConvention_64kb.mp3";
         //private string _acousticResourcePath = @"SpeechToTextTestData/TheFirstAmericaninEarthOrbit.mp3";
         private string _acousticResourceName = "firstOrbit";
         private string _acousticResourceMimeType = "audio/mpeg";

--- a/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/SpeechToTextService.cs
+++ b/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/SpeechToTextService.cs
@@ -2099,7 +2099,6 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                     restRequest.WithArgument("custom_language_model_id", customLanguageModelId);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
-                restRequest.WithArgument("force", true);
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();

--- a/test/IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests/SpeechToTextServiceIntegrationTest.cs
+++ b/test/IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests/SpeechToTextServiceIntegrationTest.cs
@@ -47,7 +47,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests
         private string _corpusPath = @"SpeechToTextTestData/theJabberwocky-utf8.txt";
         private string _acousticModelName = "dotnet-integration-test-custom-acoustic-model";
         private string _acousticModelDescription = "A custom model to teset .NET SDK Speech to Text acoustic customization.";
-        private string _acousticResourceUrl = "https://ia802302.us.archive.org/10/items/Greatest_Speeches_of_the_20th_Century/TheFirstAmericaninEarthOrbit.mp3";
+        private string _acousticResourceUrl = "https://archive.org/download/Greatest_Speeches_of_the_20th_Century/KeynoteAddressforDemocraticConvention_64kb.mp3";
         private string _acousticResourceName = "firstOrbit";
         private string _acousticResourceMimeType = "audio/mpeg";
         private SpeechToTextService _service;


### PR DESCRIPTION
### Summary
Training acoustic resources for speech to text requires an audio clip of at least 10 minutes. We were running tests and examples with a shorter audio clip and used an undocumented query parameter `force` when calling the service to train the acoustic model. This query param was handwritten in the service and required a post generation revision.

This pull request changes the acoustic resource to a file that is longer than 10 minutes and removes the handwritten `force` query parameter.