### PR TITLE
Rc 2.7.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,6 @@
 [bumpversion]
 commit = True
+current_version = 2.7.0
 
 [bumpversion:file:Doxyfile]
 
@@ -112,3 +113,4 @@ commit = True
 [bumpversion:file:test\IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests\IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests.csproj]
 search = {current_version}
 replace = {new_version}
+

--- a/.releaserc
+++ b/.releaserc
@@ -1,15 +1,6 @@
 {
   "branch": "master",
   "verifyConditions": [],
-  "prepare": [
-    {
-      "path": "@semantic-release/exec",
-      "cmd": "bumpversion --current-version ${lastRelease.version} --new-version ${nextRelease.version} --verbose patch"
-    }
-  ],
-  "publish": [
-    {
-      "path": "@semantic-release/github"
-    }
-  ]
+  "prepare": [],
+  "publish": ["@semantic-release/github"]
 }

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Watson Developer Cloud .NET Standard SDK"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.6.0
+PROJECT_NUMBER         = 2.7.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ install:
 - ps: Install-Product node $env:nodejs_version
 # install modules
 - pip install --user bumpversion
+- npm install @semantic-release/exec
 - cmd: >-
     rm -rf packages
 
@@ -111,6 +112,8 @@ after_build:
             dotnet pack .\src\IBM.WatsonDeveloperCloud.TextToSpeech.v1\IBM.WatsonDeveloperCloud.TextToSpeech.v1.csproj --configuration Release
             dotnet pack .\src\IBM.WatsonDeveloperCloud.ToneAnalyzer.v3\IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.csproj --configuration Release
             dotnet pack .\src\IBM.WatsonDeveloperCloud.VisualRecognition.v3\IBM.WatsonDeveloperCloud.VisualRecognition.v3.csproj --configuration Release
+
+            npx semantic-release
           }
           
           else
@@ -215,8 +218,6 @@ artifacts:
   name: IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1
 - path: '\src\IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1\bin\$(configuration)\*.nupkg'
   name: IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1
-before_deploy:
-- ps: npx semantic-release
 deploy:
 - provider: NuGet
   api_key:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -105,12 +105,12 @@ after_build:
             dotnet pack .\src\IBM.WatsonDeveloperCloud.LanguageTranslator.v2\IBM.WatsonDeveloperCloud.LanguageTranslator.v2.csproj --configuration Release
             dotnet pack .\src\IBM.WatsonDeveloperCloud.LanguageTranslator.v3\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.csproj --configuration Release
             dotnet pack .\src\IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1\IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1.csproj --configuration Release
-            dotnet pack .\src\IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1\IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1 --configuration Release
-            dotnet pack .\src\IBM.WatsonDeveloperCloud.PersonalityInsights.v3\IBM.WatsonDeveloperCloud.PersonalityInsights.v3 --configuration Release
-            dotnet pack .\src\IBM.WatsonDeveloperCloud.SpeechToText.v1\IBM.WatsonDeveloperCloud.SpeechToText.v1 --configuration Release
-            dotnet pack .\src\IBM.WatsonDeveloperCloud.TextToSpeech.v1\IBM.WatsonDeveloperCloud.TextToSpeech.v1 --configuration Release
-            dotnet pack .\src\IBM.WatsonDeveloperCloud.ToneAnalyzer.v3\IBM.WatsonDeveloperCloud.ToneAnalyzer.v3 --configuration Release
-            dotnet pack .\src\IBM.WatsonDeveloperCloud.VisualRecognition.v3\IBM.WatsonDeveloperCloud.VisualRecognition.v3 --configuration Release
+            dotnet pack .\src\IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1\IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.csproj --configuration Release
+            dotnet pack .\src\IBM.WatsonDeveloperCloud.PersonalityInsights.v3\IBM.WatsonDeveloperCloud.PersonalityInsights.v3.csproj --configuration Release
+            dotnet pack .\src\IBM.WatsonDeveloperCloud.SpeechToText.v1\IBM.WatsonDeveloperCloud.SpeechToText.v1.csproj --configuration Release
+            dotnet pack .\src\IBM.WatsonDeveloperCloud.TextToSpeech.v1\IBM.WatsonDeveloperCloud.TextToSpeech.v1.csproj --configuration Release
+            dotnet pack .\src\IBM.WatsonDeveloperCloud.ToneAnalyzer.v3\IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.csproj --configuration Release
+            dotnet pack .\src\IBM.WatsonDeveloperCloud.VisualRecognition.v3\IBM.WatsonDeveloperCloud.VisualRecognition.v3.csproj --configuration Release
           }
           
           else

--- a/examples/IBM.WatsonDeveloperCloud.Conversation.v1.Example/IBM.WatsonDeveloperCloud.Conversation.v1.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.Conversation.v1.Example/IBM.WatsonDeveloperCloud.Conversation.v1.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1.Example</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/examples/IBM.WatsonDeveloperCloud.Discovery.v1.Example/IBM.WatsonDeveloperCloud.Discovery.v1.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.Discovery.v1.Example/IBM.WatsonDeveloperCloud.Discovery.v1.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Discovery.v1.Example</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/examples/IBM.WatsonDeveloperCloud.LanguageTranslator.v2.Example/IBM.WatsonDeveloperCloud.LanguageTranslator.v2.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.LanguageTranslator.v2.Example/IBM.WatsonDeveloperCloud.LanguageTranslator.v2.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v2.Example</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/examples/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/examples/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.Ex/IBM.WatsonDeveloperCloud.NLU.v1.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.Ex/IBM.WatsonDeveloperCloud.NLU.v1.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.Ex</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/examples/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/examples/IBM.WatsonDeveloperCloud.SpeechToText.v1.Example/IBM.WatsonDeveloperCloud.SpeechToText.v1.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.SpeechToText.v1.Example/IBM.WatsonDeveloperCloud.SpeechToText.v1.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.SpeechToText.v1.Example</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/examples/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.Assistant.v1/IBM.WatsonDeveloperCloud.Assistant.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.Assistant.v1/IBM.WatsonDeveloperCloud.Assistant.v1.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.Assistant.v1 wraps the Watson Developer Cloud Assistant service (http://www.ibm.com/watson/developercloud/assistant.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.Assistant.v1</AssemblyTitle>
-        <VersionPrefix>2.6.0</VersionPrefix>
+        <VersionPrefix>2.7.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.Assistant.v1</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>2.6.0</Version>
+        <Version>2.7.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.Assistant.v1/README.md
+++ b/src/IBM.WatsonDeveloperCloud.Assistant.v1/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v2.6.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.Assistant.v1/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.7.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.Assistant.v1/)
 
 ### Assistant
 
@@ -15,7 +15,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.Assistant.v1
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.Assistant.v1" Version="2.6.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.Assistant.v1" Version="2.7.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.Conversation.v1/IBM.WatsonDeveloperCloud.Conversation.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.Conversation.v1/IBM.WatsonDeveloperCloud.Conversation.v1.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.Conversation.v1 wraps the Watson Developer Cloud Conversation service (http://www.ibm.com/watson/developercloud/conversation.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.Conversation.v1</AssemblyTitle>
-        <VersionPrefix>2.6.0</VersionPrefix>
+        <VersionPrefix>2.7.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>2.6.0</Version>
+        <Version>2.7.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.Conversation.v1/README.md
+++ b/src/IBM.WatsonDeveloperCloud.Conversation.v1/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v2.6.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.Conversation.v1/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.7.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.Conversation.v1/)
 
 ### Conversation
 
@@ -15,7 +15,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.Conversation.v1
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.Conversation.v1" Version="2.6.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.Conversation.v1" Version="2.7.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.Discovery.v1/IBM.WatsonDeveloperCloud.Discovery.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.Discovery.v1/IBM.WatsonDeveloperCloud.Discovery.v1.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.Discovery.v1 wraps the Watson Developer Cloud Discovery service (http://www.ibm.com/watson/developercloud/discovery.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.Discovery.v1</AssemblyTitle>
-        <VersionPrefix>2.6.0</VersionPrefix>
+        <VersionPrefix>2.7.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.Discovery.v1</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>2.6.0</Version>
+        <Version>2.7.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.Discovery.v1/README.md
+++ b/src/IBM.WatsonDeveloperCloud.Discovery.v1/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v2.6.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.Discovery.v1/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.7.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.Discovery.v1/)
 
 ### Discovery
 The IBM Watson™ [Discovery][discovery] service makes it possible to rapidly build cognitive, cloud-based exploration applications that unlock actionable insights hidden in unstructured data - including your own proprietary data, as well as public and third-party data.
@@ -14,7 +14,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.Discovery.v1
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.Discovery.v1" Version="2.6.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.Discovery.v1" Version="2.7.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v2/IBM.WatsonDeveloperCloud.LanguageTranslator.v2.csproj
+++ b/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v2/IBM.WatsonDeveloperCloud.LanguageTranslator.v2.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.LanguageTranslator.v2 wraps the Watson Developer Cloud Language Translator service (http://www.ibm.com/watson/developercloud/language-translator.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.LanguageTranslator.v2</AssemblyTitle>
-        <VersionPrefix>2.6.0</VersionPrefix>
+        <VersionPrefix>2.7.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v2</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>2.6.0</Version>
+        <Version>2.7.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v2/README.md
+++ b/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v2/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v2.6.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.LanguageTranslator.v2/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.7.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.LanguageTranslator.v2/)
 
 ### Language Translator V2
 **Language Translator v3 is now available. The v2 Language Translator API will no longer be available after July 31, 2018. To take advantage of the latest service enhancements, migrate to the v3 API. View the [Migrating to Language Translator v3](https://console.bluemix.net/docs/services/language-translator/migrating.html) page for more information.**
@@ -16,7 +16,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.LanguageTranslator.v2
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.LanguageTranslator.v2" Version="2.6.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.LanguageTranslator.v2" Version="2.7.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.csproj
+++ b/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.LanguageTranslator.v3 wraps the Watson Developer Cloud Language Translator service (http://www.ibm.com/watson/developercloud/language-translator.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.LanguageTranslator.v3</AssemblyTitle>
-        <VersionPrefix>2.6.0</VersionPrefix>
+        <VersionPrefix>2.7.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v3</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>2.6.0</Version>
+        <Version>2.7.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/README.md
+++ b/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v2.6.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.7.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/)
 
 ### Language Translator V3
 
@@ -15,7 +15,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.LanguageTranslator.v3
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.LanguageTranslator.v3" Version="2.6.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.LanguageTranslator.v3" Version="2.7.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1 wraps the Watson Developer Cloud Natural Language Classifier service (http://www.ibm.com/watson/developercloud/natural-language-classifier.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1</AssemblyTitle>
-        <VersionPrefix>2.6.0</VersionPrefix>
+        <VersionPrefix>2.7.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>2.6.0</Version>
+        <Version>2.7.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1/README.md
+++ b/src/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v2.6.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.7.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1/)
 
 ### Natural Language Classifier
 IBM Watson™ [Natural Language Classifier][natural_language_classifier] uses machine learning algorithms to return the top matching predefined classes for short text input. You create and train a classifier to connect predefined classes to example texts so that the service can apply those classes to new inputs.
@@ -14,7 +14,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.NaturalLangaugeClassifier.v1" Version="2.6.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.NaturalLangaugeClassifier.v1" Version="2.7.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1 wraps the Watson Developer Cloud Natural Language Understanding service (http://www.ibm.com/watson/developercloud/natural-language-understanding.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1</AssemblyTitle>
-        <VersionPrefix>2.6.0</VersionPrefix>
+        <VersionPrefix>2.7.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>2.6.0</Version>
+        <Version>2.7.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1/README.md
+++ b/src/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v2.6.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.7.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1/)
 
 ### Natural Language Understanding
 With [Natural Language Understanding][natural_language_understanding] developers can analyze semantic features of text input, including - categories, concepts, emotion, entities, keywords, metadata, relations, semantic roles, and sentiment.
@@ -14,7 +14,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1" Version="2.6.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1" Version="2.7.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.PersonalityInsights.v3/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.csproj
+++ b/src/IBM.WatsonDeveloperCloud.PersonalityInsights.v3/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.PersonalityInsights.v3 wraps the Watson Developer Cloud Personality Insights service (http://www.ibm.com/watson/developercloud/personality-insights.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.PersonalityInsights.v3</AssemblyTitle>
-        <VersionPrefix>2.6.0</VersionPrefix>
+        <VersionPrefix>2.7.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.PersonalityInsights.v3</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>2.6.0</Version>
+        <Version>2.7.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.PersonalityInsights.v3/README.md
+++ b/src/IBM.WatsonDeveloperCloud.PersonalityInsights.v3/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v2.6.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.PersonalityInsights.v3/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.7.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.PersonalityInsights.v3/)
 
 ### Personality Insights
 
@@ -19,7 +19,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.PersonalityInsights.v3
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.PersonalityInsights.v3" Version="2.6.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.PersonalityInsights.v3" Version="2.7.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/IBM.WatsonDeveloperCloud.SpeechToText.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/IBM.WatsonDeveloperCloud.SpeechToText.v1.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.SpeechToText.v1 wraps the Watson Developer Cloud Speech To Text service (http://www.ibm.com/watson/developercloud/speech-to-text.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.SpeechToText.v1</AssemblyTitle>
-        <VersionPrefix>2.6.0</VersionPrefix>
+        <VersionPrefix>2.7.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.SpeechToText.v1</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>2.6.0</Version>
+        <Version>2.7.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/README.md
+++ b/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v2.6.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.SpeechToText.v1/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.7.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.SpeechToText.v1/)
 
 ### Speech to Text
 
@@ -15,7 +15,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.SpeechToText.v1
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.SpeechToText.v1" Version="2.6.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.SpeechToText.v1" Version="2.7.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.TextToSpeech.v1/IBM.WatsonDeveloperCloud.TextToSpeech.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.TextToSpeech.v1/IBM.WatsonDeveloperCloud.TextToSpeech.v1.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.TextToSpeech.v1 wraps the Watson Developer Cloud Text To Speech service (http://www.ibm.com/watson/developercloud/text-to-speech.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.TextToSpeech.v1</AssemblyTitle>
-        <VersionPrefix>2.6.0</VersionPrefix>
+        <VersionPrefix>2.7.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.TextToSpeech.v1</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>2.6.0</Version>
+        <Version>2.7.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.csproj
+++ b/src/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3 wraps the Watson Developer Cloud Tone Analyzer service (http://www.ibm.com/watson/developercloud/tone-analyzer.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3</AssemblyTitle>
-        <VersionPrefix>2.6.0</VersionPrefix>
+        <VersionPrefix>2.7.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>2.6.0</Version>
+        <Version>2.7.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3/README.md
+++ b/src/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v2.6.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.7.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3/)
 
 ### Tone Analyzer
 
@@ -15,7 +15,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.ToneAnalyzer.v3
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.ToneAnalyzer.v3" Version="2.6.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.ToneAnalyzer.v3" Version="2.7.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/IBM.WatsonDeveloperCloud.VisualRecognition.v3.csproj
+++ b/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/IBM.WatsonDeveloperCloud.VisualRecognition.v3.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.VisualRecognition.v3 wraps the Watson Developer Cloud Visual Recognition service (http://www.ibm.com/watson/developercloud/visual-recognition.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.VisualRecognition.v3</AssemblyTitle>
-        <VersionPrefix>2.6.0</VersionPrefix>
+        <VersionPrefix>2.7.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.VisualRecognition.v3</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>2.6.0</Version>
+        <Version>2.7.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/README.md
+++ b/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v2.6.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.VisualRecognition.v3/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.7.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.VisualRecognition.v3/)
 
 ### Visual Recognition
 The IBM Watson™ [Visual Recognition][visual-recognition] service uses deep learning algorithms to identify scenes, objects, and celebrity faces in images you upload to the service. You can create and train a custom classifier to identify subjects that suit your needs.
@@ -14,7 +14,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.VisualRecognition.v3
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.VisualRecognition.v3" Version="2.6.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.VisualRecognition.v3" Version="2.7.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud/Constants.cs
+++ b/src/IBM.WatsonDeveloperCloud/Constants.cs
@@ -26,7 +26,7 @@ namespace IBM.WatsonDeveloperCloud
         /// The version number for this SDK build. Added to the header in 
         /// each request as `User-Agent`.
         /// </summary>
-        public const string SDK_VERSION = "watson-apis-dotnet-sdk/2.6.0";
+        public const string SDK_VERSION = "watson-apis-dotnet-sdk/2.7.0";
         /// <summary>
         /// A constant used to access custom request headers in the dynamic
         /// customData object.

--- a/src/IBM.WatsonDeveloperCloud/IBM.WatsonDeveloperCloud.csproj
+++ b/src/IBM.WatsonDeveloperCloud/IBM.WatsonDeveloperCloud.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>The IBM.WatsonDeveloperCloud is a core project of Watson SDK in .Net. The other Watson SDK in .Net service packages depend on this package.</Description>
     <AssemblyTitle>IBM.WatsonDeveloperCloud</AssemblyTitle>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <Authors>Watson Developer Cloud</Authors>
     <TargetFramework>netstandard1.3</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud</AssemblyName>
@@ -15,7 +15,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud/README.md
+++ b/src/IBM.WatsonDeveloperCloud/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v2.6.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.7.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud/)
 
 ### Watson Developer Cloud
 
@@ -15,7 +15,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud" Version="2.6.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud" Version="2.7.0" />
 </ItemGroup>
 
 ```

--- a/test/IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests/IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests/IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests/IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests/IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v2.IntegrationTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v2.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v2.IntegrationTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v2.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v2.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.LanguageTranslator.v2.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v2.UnitTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v2.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v2.UnitTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v2.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v2.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.LanguageTranslator.v2.UnitTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests/IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests/IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.IntTests/IBM.WatsonDeveloperCloud.NLU.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.IntTests/IBM.WatsonDeveloperCloud.NLU.v1.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.IntTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.IntTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.UnitTests/IBM.WatsonDeveloperCloud.NLU.v1.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.UnitTests/IBM.WatsonDeveloperCloud.NLU.v1.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.UnitTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntTests/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntTests/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests/IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests/IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests/IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests/IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
### Summary
This pull request revises semantic-release. We now run bumpversion manually before merging to master since it needs to happen before the `dotnet pack` command. We install `semantic-release` in the install phase and run the command after `dotnet pack` has completed.