### PR TITLE
Hotfix collection id array

### DIFF
--- a/src/IBM.WatsonDeveloperCloud.Discovery.v1/DiscoveryService.cs
+++ b/src/IBM.WatsonDeveloperCloud.Discovery.v1/DiscoveryService.cs
@@ -1634,7 +1634,7 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                     PassagesCharacters = passagesCharacters,
                     Deduplicate = deduplicate,
                     DeduplicateField = deduplicateField,
-                    CollectionIds = (collectionIds == null || collectionIds.Count < 1) ? null : string.Join(", ", collectionIds.ToArray()),
+                    CollectionIds = collectionIds,
                     Similar = similar,
                     SimilarDocumentIds = (similarDocumentIds == null || similarDocumentIds.Count < 1) ? null : string.Join(", ", similarDocumentIds.ToArray()),
                     SimilarFields = (similarFields == null || similarFields.Count < 1) ? null : string.Join(", ", similarFields.ToArray()),

--- a/src/IBM.WatsonDeveloperCloud.Discovery.v1/Model/QueryLarge.cs
+++ b/src/IBM.WatsonDeveloperCloud.Discovery.v1/Model/QueryLarge.cs
@@ -16,6 +16,7 @@
 */
 
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace IBM.WatsonDeveloperCloud.Discovery.v1.Model
 {
@@ -120,7 +121,7 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1.Model
         /// invalid when performing a single collection query.
         /// </summary>
         [JsonProperty("collection_ids", NullValueHandling = NullValueHandling.Ignore)]
-        public string CollectionIds { get; set; }
+        public List<string> CollectionIds { get; set; }
         /// <summary>
         /// When `true`, results are returned based on their similarity to the document IDs specified in the
         /// **similar.document_ids** parameter.

--- a/test/IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests/DiscoveryIntegrationTests.cs
+++ b/test/IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests/DiscoveryIntegrationTests.cs
@@ -339,11 +339,19 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests
             rFields.Add("extracted_metadata.sha1");
             var queryResult = Query(_environmentId, _createdCollectionId, null, null, _naturalLanguageQuery, returnFields:rFields);
 
+            var collectionIds = new List<string>()
+            {
+                _createdCollectionId
+            };
+
+            var federatedQueryResult = FederatedQuery(_environmentId, collectionIds, naturalLanguageQuery: _naturalLanguageQuery);
+
             var deleteDocumentResult = DeleteDocument(_environmentId, _createdCollectionId, _createdDocumentId);
             var deleteCollectionResult = DeleteCollection(_environmentId, _createdCollectionId);
             var deleteConfigurationResults = DeleteConfiguration(_environmentId, _createdConfigurationId);
 
             Assert.IsNotNull(queryResult);
+            Assert.IsNotNull(federatedQueryResult);
 
             _createdDocumentId = null;
             _createdCollectionId = null;


### PR DESCRIPTION
### Summary
Collection IDs are now sent as a json array rather than a comma separated string.