### PR TITLE
fix(http request): Cleared out accept header if a file is returned

### DIFF
--- a/src/IBM.WatsonDeveloperCloud.TextToSpeech.v1/TextToSpeechService.cs
+++ b/src/IBM.WatsonDeveloperCloud.TextToSpeech.v1/TextToSpeechService.cs
@@ -199,7 +199,7 @@ namespace IBM.WatsonDeveloperCloud.TextToSpeech.v1
         /// that owns the custom model. Omit the parameter to use the specified voice with no customization.
         /// (optional)</param>
         /// <param name="customData">Custom data object to pass data including custom request headers.</param>
-        /// <returns><see cref="System.IO.FileStream" />System.IO.FileStream</returns>
+        /// <returns><see cref="System.IO.MemoryStream" />System.IO.MemoryStream</returns>
         public System.IO.MemoryStream Synthesize(Text text, string accept = null, string voice = null, string customizationId = null, Dictionary<string, object> customData = null)
         {
             if (text == null)

--- a/src/IBM.WatsonDeveloperCloud/Http/Request.cs
+++ b/src/IBM.WatsonDeveloperCloud/Http/Request.cs
@@ -81,6 +81,10 @@ namespace IBM.WatsonDeveloperCloud.Http
 
         public IRequest WithHeader(string key, string value)
         {
+            if (key == "Accept" && value.StartsWith("audio/", StringComparison.OrdinalIgnoreCase))
+            {
+                this.Message.Headers.Accept.Clear();
+            }
             this.Message.Headers.TryAddWithoutValidation(key, value);
             return this;
         }


### PR DESCRIPTION
If you try to use the Text to Speech, the MemoryStream returns json as the first Accept is "application/json".

### Summary

If you try to use Synthesize and get the MemoryStream, the stream is actually a json file as the Accept header is application/json,application/xml,audio/mp3 and so at least in a console app, the first thing it can accept is json, so it will return json. by clearing out all the accept only when there's audio present, the audio gets first dibs. 