### PR TITLE
Implement bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -122,4 +122,3 @@ message = [skip ci] docs: Update version numbers from {current_version} -> {new_
 [bumpversion:file:test\IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests\IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests.csproj]
 search = {current_version}
 replace = {new_version}
-

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,14 +1,15 @@
 [bumpversion]
 commit = True
 current_version = 2.12.0
+message = [skip ci] docs: Update version numbers from {current_version} -> {new_version}
 
 [bumpversion:file:Doxyfile]
+
+[bumpversion:file:examples\IBM.WatsonDeveloperCloud.Assistant.v2.Example\IBM.WatsonDeveloperCloud.Assistant.v2.Example.csproj]
 
 [bumpversion:file:examples\IBM.WatsonDeveloperCloud.Conversation.v1.Example\IBM.WatsonDeveloperCloud.Conversation.v1.Example.csproj]
 
 [bumpversion:file:examples\IBM.WatsonDeveloperCloud.Discovery.v1.Example\IBM.WatsonDeveloperCloud.Discovery.v1.Example.csproj]
-
-[bumpversion:file:examples\IBM.WatsonDeveloperCloud.LanguageTranslator.v2.Example\IBM.WatsonDeveloperCloud.LanguageTranslator.v2.Example.csproj]
 
 [bumpversion:file:examples\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example.csproj]
 
@@ -24,9 +25,13 @@ current_version = 2.12.0
 
 [bumpversion:file:src\IBM.WatsonDeveloperCloud.Assistant.v1\README.md]
 
-[bumpversion:file:src\IBM.WatsonDeveloperCloud.Assistant.v1\IBM.WatsonDeveloperCloud.Assistant.v2.csproj]
+[bumpversion:file:src\IBM.WatsonDeveloperCloud.Assistant.v2\IBM.WatsonDeveloperCloud.Assistant.v2.csproj]
 
 [bumpversion:file:src\IBM.WatsonDeveloperCloud.Assistant.v2\README.md]
+
+[bumpversion:file:src\IBM.WatsonDeveloperCloud.CompareComply.v1\IBM.WatsonDeveloperCloud.CompareComply.v1.csproj]
+
+[bumpversion:file:src\IBM.WatsonDeveloperCloud.CompareComply.v1\README.md]
 
 [bumpversion:file:src\IBM.WatsonDeveloperCloud.Conversation.v1\IBM.WatsonDeveloperCloud.Conversation.v1.csproj]
 
@@ -35,10 +40,6 @@ current_version = 2.12.0
 [bumpversion:file:src\IBM.WatsonDeveloperCloud.Discovery.v1\IBM.WatsonDeveloperCloud.Discovery.v1.csproj]
 
 [bumpversion:file:src\IBM.WatsonDeveloperCloud.Discovery.v1\README.md]
-
-[bumpversion:file:src\IBM.WatsonDeveloperCloud.LanguageTranslator.v2\IBM.WatsonDeveloperCloud.LanguageTranslator.v2.csproj]
-
-[bumpversion:file:src\IBM.WatsonDeveloperCloud.LanguageTranslator.v2\README.md]
 
 [bumpversion:file:src\IBM.WatsonDeveloperCloud.LanguageTranslator.v3\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.csproj]
 
@@ -80,9 +81,13 @@ current_version = 2.12.0
 
 [bumpversion:file:test\IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests\IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests.csproj]
 
-[bumpversion:file:test\IBM.WatsonDeveloperCloud.Assistant.v2.IntegrationTests\IBM.WatsonDeveloperCloud.Assistant.v2.IntegrationTests.csproj]
+[bumpversion:file:test\IBM.WatsonDeveloperCloud.Assistant.v2.IntTests\IBM.WatsonDeveloperCloud.Assistant.v2.IntTests.csproj]
 
 [bumpversion:file:test\IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests\IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests.csproj]
+
+[bumpversion:file:test\IBM.WatsonDeveloperCloud.CompareComply.v1.IT\IBM.WatsonDeveloperCloud.CompareComply.v1.IT.csproj]
+
+[bumpversion:file:test\IBM.WatsonDeveloperCloud.CompareComply.v1.UT\IBM.WatsonDeveloperCloud.CompareComply.v1.UT.csproj]
 
 [bumpversion:file:test\IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests\IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests.csproj]
 
@@ -91,10 +96,6 @@ current_version = 2.12.0
 [bumpversion:file:test\IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests\IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests.csproj]
 
 [bumpversion:file:test\IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests\IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests.csproj]
-
-[bumpversion:file:test\IBM.WatsonDeveloperCloud.LanguageTranslator.v2.IntegrationTests\IBM.WatsonDeveloperCloud.LanguageTranslator.v2.IntegrationTests.csproj]
-
-[bumpversion:file:test\IBM.WatsonDeveloperCloud.LanguageTranslator.v2.UnitTests\IBM.WatsonDeveloperCloud.LanguageTranslator.v2.UnitTests.csproj]
 
 [bumpversion:file:test\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests.csproj]
 

--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,24 @@
 {
   "branch": "master",
   "verifyConditions": [],
-  "prepare": [],
+  "prepare": [
+    {
+      "path": "@semantic-release/exec",
+      "cmd": "bumpversion --current-version ${lastRelease.version} --new-version ${nextRelease.version} patch"
+      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud\IBM.WatsonDeveloperCloud.csproj --configuration Release"
+      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.Assistant.v1\IBM.WatsonDeveloperCloud.Assistant.v1.csproj --configuration Release
+      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.CompareComply.v1\IBM.WatsonDeveloperCloud.CompareComply.v1.csproj --configuration Release
+      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.Conversation.v1\IBM.WatsonDeveloperCloud.Conversation.v1.csproj --configuration Release
+      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.Discovery.v1\IBM.WatsonDeveloperCloud.Discovery.v1.csproj --configuration Release
+      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.LanguageTranslator.v3\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.csproj --configuration Release
+      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1\IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1.csproj --configuration Release
+      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1\IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.csproj --configuration Release
+      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.PersonalityInsights.v3\IBM.WatsonDeveloperCloud.PersonalityInsights.v3.csproj --configuration Release
+      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.SpeechToText.v1\IBM.WatsonDeveloperCloud.SpeechToText.v1.csproj --configuration Release
+      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.TextToSpeech.v1\IBM.WatsonDeveloperCloud.TextToSpeech.v1.csproj --configuration Release
+      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.ToneAnalyzer.v3\IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.csproj --configuration Release
+      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.VisualRecognition.v3\IBM.WatsonDeveloperCloud.VisualRecognition.v3.csproj --configuration Release
+    }
+  ],
   "publish": ["@semantic-release/github"]
 }

--- a/.releaserc
+++ b/.releaserc
@@ -4,20 +4,20 @@
   "prepare": [
     {
       "path": "@semantic-release/exec",
-      "cmd": "bumpversion --current-version ${lastRelease.version} --new-version ${nextRelease.version} patch"
-      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud\IBM.WatsonDeveloperCloud.csproj --configuration Release"
-      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.Assistant.v1\IBM.WatsonDeveloperCloud.Assistant.v1.csproj --configuration Release
-      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.CompareComply.v1\IBM.WatsonDeveloperCloud.CompareComply.v1.csproj --configuration Release
-      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.Conversation.v1\IBM.WatsonDeveloperCloud.Conversation.v1.csproj --configuration Release
-      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.Discovery.v1\IBM.WatsonDeveloperCloud.Discovery.v1.csproj --configuration Release
-      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.LanguageTranslator.v3\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.csproj --configuration Release
-      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1\IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1.csproj --configuration Release
-      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1\IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.csproj --configuration Release
-      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.PersonalityInsights.v3\IBM.WatsonDeveloperCloud.PersonalityInsights.v3.csproj --configuration Release
-      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.SpeechToText.v1\IBM.WatsonDeveloperCloud.SpeechToText.v1.csproj --configuration Release
-      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.TextToSpeech.v1\IBM.WatsonDeveloperCloud.TextToSpeech.v1.csproj --configuration Release
-      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.ToneAnalyzer.v3\IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.csproj --configuration Release
-      "cmd": "dotnet pack .\src\IBM.WatsonDeveloperCloud.VisualRecognition.v3\IBM.WatsonDeveloperCloud.VisualRecognition.v3.csproj --configuration Release
+      "cmd": "bumpversion --current-version ${lastRelease.version} --new-version ${nextRelease.version} patch
+      dotnet pack .\\src\\IBM.WatsonDeveloperCloud\\IBM.WatsonDeveloperCloud.csproj --configuration Release
+      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.Assistant.v1\\IBM.WatsonDeveloperCloud.Assistant.v1.csproj --configuration Release
+      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.CompareComply.v1\\IBM.WatsonDeveloperCloud.CompareComply.v1.csproj --configuration Release
+      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.Conversation.v1\\IBM.WatsonDeveloperCloud.Conversation.v1.csproj --configuration Release
+      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.Discovery.v1\\IBM.WatsonDeveloperCloud.Discovery.v1.csproj --configuration Release
+      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.LanguageTranslator.v3\\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.csproj --configuration Release
+      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1\\IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1.csproj --configuration Release
+      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1\\IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.csproj --configuration Release
+      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.PersonalityInsights.v3\\IBM.WatsonDeveloperCloud.PersonalityInsights.v3.csproj --configuration Release
+      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.SpeechToText.v1\\IBM.WatsonDeveloperCloud.SpeechToText.v1.csproj --configuration Release
+      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.TextToSpeech.v1\\IBM.WatsonDeveloperCloud.TextToSpeech.v1.csproj --configuration Release
+      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.ToneAnalyzer.v3\\IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.csproj --configuration Release
+      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.VisualRecognition.v3\\IBM.WatsonDeveloperCloud.VisualRecognition.v3.csproj --configuration Release"
     }
   ],
   "publish": ["@semantic-release/github"]

--- a/.releaserc
+++ b/.releaserc
@@ -4,20 +4,7 @@
   "prepare": [
     {
       "path": "@semantic-release/exec",
-      "cmd": "bumpversion --current-version ${lastRelease.version} --new-version ${nextRelease.version} patch
-      dotnet pack .\\src\\IBM.WatsonDeveloperCloud\\IBM.WatsonDeveloperCloud.csproj --configuration Release
-      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.Assistant.v1\\IBM.WatsonDeveloperCloud.Assistant.v1.csproj --configuration Release
-      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.CompareComply.v1\\IBM.WatsonDeveloperCloud.CompareComply.v1.csproj --configuration Release
-      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.Conversation.v1\\IBM.WatsonDeveloperCloud.Conversation.v1.csproj --configuration Release
-      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.Discovery.v1\\IBM.WatsonDeveloperCloud.Discovery.v1.csproj --configuration Release
-      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.LanguageTranslator.v3\\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.csproj --configuration Release
-      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1\\IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1.csproj --configuration Release
-      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1\\IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.csproj --configuration Release
-      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.PersonalityInsights.v3\\IBM.WatsonDeveloperCloud.PersonalityInsights.v3.csproj --configuration Release
-      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.SpeechToText.v1\\IBM.WatsonDeveloperCloud.SpeechToText.v1.csproj --configuration Release
-      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.TextToSpeech.v1\\IBM.WatsonDeveloperCloud.TextToSpeech.v1.csproj --configuration Release
-      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.ToneAnalyzer.v3\\IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.csproj --configuration Release
-      dotnet pack .\\src\\IBM.WatsonDeveloperCloud.VisualRecognition.v3\\IBM.WatsonDeveloperCloud.VisualRecognition.v3.csproj --configuration Release"
+      "cmd": "bumpversion --current-version ${lastRelease.version} --new-version ${nextRelease.version} patch"
     }
   ],
   "publish": ["@semantic-release/github"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -98,21 +98,6 @@ after_build:
           If($branchName -eq "master")
 
           {
-            Write-Output "branchName  is master - building nuget packages"
-            dotnet pack .\src\IBM.WatsonDeveloperCloud\IBM.WatsonDeveloperCloud.csproj --configuration Release
-            dotnet pack .\src\IBM.WatsonDeveloperCloud.Assistant.v1\IBM.WatsonDeveloperCloud.Assistant.v1.csproj --configuration Release
-            dotnet pack .\src\IBM.WatsonDeveloperCloud.CompareComply.v1\IBM.WatsonDeveloperCloud.CompareComply.v1.csproj --configuration Release
-            dotnet pack .\src\IBM.WatsonDeveloperCloud.Conversation.v1\IBM.WatsonDeveloperCloud.Conversation.v1.csproj --configuration Release
-            dotnet pack .\src\IBM.WatsonDeveloperCloud.Discovery.v1\IBM.WatsonDeveloperCloud.Discovery.v1.csproj --configuration Release
-            dotnet pack .\src\IBM.WatsonDeveloperCloud.LanguageTranslator.v3\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.csproj --configuration Release
-            dotnet pack .\src\IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1\IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1.csproj --configuration Release
-            dotnet pack .\src\IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1\IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.csproj --configuration Release
-            dotnet pack .\src\IBM.WatsonDeveloperCloud.PersonalityInsights.v3\IBM.WatsonDeveloperCloud.PersonalityInsights.v3.csproj --configuration Release
-            dotnet pack .\src\IBM.WatsonDeveloperCloud.SpeechToText.v1\IBM.WatsonDeveloperCloud.SpeechToText.v1.csproj --configuration Release
-            dotnet pack .\src\IBM.WatsonDeveloperCloud.TextToSpeech.v1\IBM.WatsonDeveloperCloud.TextToSpeech.v1.csproj --configuration Release
-            dotnet pack .\src\IBM.WatsonDeveloperCloud.ToneAnalyzer.v3\IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.csproj --configuration Release
-            dotnet pack .\src\IBM.WatsonDeveloperCloud.VisualRecognition.v3\IBM.WatsonDeveloperCloud.VisualRecognition.v3.csproj --configuration Release
-
             npx semantic-release
           }
           

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
 # Get the latest stable version of Node.js or io.js
 - ps: Install-Product node $env:nodejs_version
 # install modules
-- pip install --user bumpversion
+- pip install --user git+git://github.com/smsearcy/bumpversion.git@issue-135
 - npm install @semantic-release/exec
 - cmd: >-
     rm -rf packages

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -99,12 +99,27 @@ after_build:
 
           {
             npx semantic-release
+
+            Write-Output "branchName  is master - building nuget packages"
+            dotnet pack .\src\IBM.WatsonDeveloperCloud\IBM.WatsonDeveloperCloud.csproj --configuration Release
+            dotnet pack .\src\IBM.WatsonDeveloperCloud.Assistant.v1\IBM.WatsonDeveloperCloud.Assistant.v1.csproj --configuration Release
+            dotnet pack .\src\IBM.WatsonDeveloperCloud.CompareComply.v1\IBM.WatsonDeveloperCloud.CompareComply.v1.csproj --configuration Release
+            dotnet pack .\src\IBM.WatsonDeveloperCloud.Conversation.v1\IBM.WatsonDeveloperCloud.Conversation.v1.csproj --configuration Release
+            dotnet pack .\src\IBM.WatsonDeveloperCloud.Discovery.v1\IBM.WatsonDeveloperCloud.Discovery.v1.csproj --configuration Release
+            dotnet pack .\src\IBM.WatsonDeveloperCloud.LanguageTranslator.v3\IBM.WatsonDeveloperCloud.LanguageTranslator.v3.csproj --configuration Release
+            dotnet pack .\src\IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1\IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1.csproj --configuration Release
+            dotnet pack .\src\IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1\IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.csproj --configuration Release
+            dotnet pack .\src\IBM.WatsonDeveloperCloud.PersonalityInsights.v3\IBM.WatsonDeveloperCloud.PersonalityInsights.v3.csproj --configuration Release
+            dotnet pack .\src\IBM.WatsonDeveloperCloud.SpeechToText.v1\IBM.WatsonDeveloperCloud.SpeechToText.v1.csproj --configuration Release
+            dotnet pack .\src\IBM.WatsonDeveloperCloud.TextToSpeech.v1\IBM.WatsonDeveloperCloud.TextToSpeech.v1.csproj --configuration Release
+            dotnet pack .\src\IBM.WatsonDeveloperCloud.ToneAnalyzer.v3\IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.csproj --configuration Release
+            dotnet pack .\src\IBM.WatsonDeveloperCloud.VisualRecognition.v3\IBM.WatsonDeveloperCloud.VisualRecognition.v3.csproj --configuration Release
           }
           
           else
 
           {
-            Write-Output "branchName is not master - do not pack."
+            Write-Output "branchName is not master - do not pack or run semantic-release."
           }
 
       }


### PR DESCRIPTION
### Summary
This pull request implements bumpversion to the build process. This will allow us to do a release without creating an rc branch to manually bump version. Additionally we should be able to delete the develop branch of the repo and do automatic releases as feature branches are merged into master. 

Note: We have to use an alternate version of bumpversion since there is a commit error in Windows with the current version. 

Also `semantic-release` is being called before the `dotnet pack` step so we pack the bumpversion change. This is fine since the deploy is happening at the end of the appveyor build rather than in `semantic-release`.