### PR TITLE
Moved disabled property from CreateDialogNode to DialogNode

### DIFF
--- a/src/IBM.WatsonDeveloperCloud.Assistant.v1/Model/CreateDialogNode.cs
+++ b/src/IBM.WatsonDeveloperCloud.Assistant.v1/Model/CreateDialogNode.cs
@@ -292,12 +292,6 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1.Model
         [JsonProperty("context", NullValueHandling = NullValueHandling.Ignore)]
         public object Context { get; set; }
         /// <summary>
-        /// Whether to consider the dialog node during runtime evaluation.  Set to `true` to ignore the 
-        /// dialog node.
-        /// </summary>
-        [JsonProperty("disabled", NullValueHandling = NullValueHandling.Ignore)]
-        public bool Disabled { get; set; }
-        /// <summary>
         /// The metadata for the dialog node.
         /// </summary>
         [JsonProperty("metadata", NullValueHandling = NullValueHandling.Ignore)]

--- a/src/IBM.WatsonDeveloperCloud.Assistant.v1/Model/DialogNode.cs
+++ b/src/IBM.WatsonDeveloperCloud.Assistant.v1/Model/DialogNode.cs
@@ -320,6 +320,11 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1.Model
         [JsonProperty("title", NullValueHandling = NullValueHandling.Ignore)]
         public string Title { get; set; }
         /// <summary>
+        /// For internal use only.
+        /// </summary>
+        [JsonProperty("disabled", NullValueHandling = NullValueHandling.Ignore)]
+        public bool Disabled { get; set; }
+        /// <summary>
         /// The location in the dialog context where output is stored.
         /// </summary>
         [JsonProperty("variable", NullValueHandling = NullValueHandling.Ignore)]


### PR DESCRIPTION
### Summary
This pull request moves the `disabled` field from `CreateDialogNode` to `DialogNode` since this field is only in the response.