### PR TITLE
chore(User-Agent): Updated user-agent to include environment information

### DIFF
--- a/src/IBM.WatsonDeveloperCloud.Assistant.v1/AssistantService.cs
+++ b/src/IBM.WatsonDeveloperCloud.Assistant.v1/AssistantService.cs
@@ -130,6 +130,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithBody<MessageRequest>(request);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=Message");
                 result = restRequest.As<MessageResponse>().Result;
                 if(result == null)
                     result = new MessageResponse();
@@ -181,6 +183,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithBody<CreateWorkspace>(properties);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=CreateWorkspace");
                 result = restRequest.As<Workspace>().Result;
                 if(result == null)
                     result = new Workspace();
@@ -230,6 +234,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=DeleteWorkspace");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -294,6 +300,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("sort", sort);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=GetWorkspace");
                 result = restRequest.As<WorkspaceExport>().Result;
                 if(result == null)
                     result = new WorkspaceExport();
@@ -359,6 +367,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("include_audit", includeAudit);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=ListWorkspaces");
                 result = restRequest.As<WorkspaceCollection>().Result;
                 if(result == null)
                     result = new WorkspaceCollection();
@@ -424,6 +434,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithBody<UpdateWorkspace>(properties);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=UpdateWorkspace");
                 result = restRequest.As<Workspace>().Result;
                 if(result == null)
                     result = new Workspace();
@@ -476,6 +488,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithBody<CreateIntent>(body);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=CreateIntent");
                 result = restRequest.As<Intent>().Result;
                 if(result == null)
                     result = new Intent();
@@ -528,6 +542,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=DeleteIntent");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -590,6 +606,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("include_audit", includeAudit);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=GetIntent");
                 result = restRequest.As<IntentExport>().Result;
                 if(result == null)
                     result = new IntentExport();
@@ -664,6 +682,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("include_audit", includeAudit);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=ListIntents");
                 result = restRequest.As<IntentCollection>().Result;
                 if(result == null)
                     result = new IntentCollection();
@@ -726,6 +746,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithBody<UpdateIntent>(body);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=UpdateIntent");
                 result = restRequest.As<Intent>().Result;
                 if(result == null)
                     result = new Intent();
@@ -781,6 +803,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithBody<CreateExample>(body);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=CreateExample");
                 result = restRequest.As<Example>().Result;
                 if(result == null)
                     result = new Example();
@@ -836,6 +860,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=DeleteExample");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -895,6 +921,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("include_audit", includeAudit);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=GetExample");
                 result = restRequest.As<Example>().Result;
                 if(result == null)
                     result = new Example();
@@ -966,6 +994,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("include_audit", includeAudit);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=ListExamples");
                 result = restRequest.As<ExampleCollection>().Result;
                 if(result == null)
                     result = new ExampleCollection();
@@ -1025,6 +1055,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithBody<UpdateExample>(body);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=UpdateExample");
                 result = restRequest.As<Example>().Result;
                 if(result == null)
                     result = new Example();
@@ -1078,6 +1110,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithBody<CreateCounterexample>(body);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=CreateCounterexample");
                 result = restRequest.As<Counterexample>().Result;
                 if(result == null)
                     result = new Counterexample();
@@ -1131,6 +1165,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=DeleteCounterexample");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -1188,6 +1224,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("include_audit", includeAudit);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=GetCounterexample");
                 result = restRequest.As<Counterexample>().Result;
                 if(result == null)
                     result = new Counterexample();
@@ -1257,6 +1295,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("include_audit", includeAudit);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=ListCounterexamples");
                 result = restRequest.As<CounterexampleCollection>().Result;
                 if(result == null)
                     result = new CounterexampleCollection();
@@ -1314,6 +1354,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithBody<UpdateCounterexample>(body);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=UpdateCounterexample");
                 result = restRequest.As<Counterexample>().Result;
                 if(result == null)
                     result = new Counterexample();
@@ -1366,6 +1408,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithBody<CreateEntity>(properties);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=CreateEntity");
                 result = restRequest.As<Entity>().Result;
                 if(result == null)
                     result = new Entity();
@@ -1418,6 +1462,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=DeleteEntity");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -1480,6 +1526,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("include_audit", includeAudit);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=GetEntity");
                 result = restRequest.As<EntityExport>().Result;
                 if(result == null)
                     result = new EntityExport();
@@ -1554,6 +1602,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("include_audit", includeAudit);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=ListEntities");
                 result = restRequest.As<EntityCollection>().Result;
                 if(result == null)
                     result = new EntityCollection();
@@ -1615,6 +1665,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithBody<UpdateEntity>(properties);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=UpdateEntity");
                 result = restRequest.As<Entity>().Result;
                 if(result == null)
                     result = new Entity();
@@ -1676,6 +1728,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("include_audit", includeAudit);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=ListMentions");
                 result = restRequest.As<EntityMentionCollection>().Result;
                 if(result == null)
                     result = new EntityMentionCollection();
@@ -1731,6 +1785,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithBody<CreateValue>(properties);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=CreateValue");
                 result = restRequest.As<Value>().Result;
                 if(result == null)
                     result = new Value();
@@ -1786,6 +1842,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=DeleteValue");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -1850,6 +1908,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("include_audit", includeAudit);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=GetValue");
                 result = restRequest.As<ValueExport>().Result;
                 if(result == null)
                     result = new ValueExport();
@@ -1926,6 +1986,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("include_audit", includeAudit);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=ListValues");
                 result = restRequest.As<ValueCollection>().Result;
                 if(result == null)
                     result = new ValueCollection();
@@ -1991,6 +2053,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithBody<UpdateValue>(properties);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=UpdateValue");
                 result = restRequest.As<Value>().Result;
                 if(result == null)
                     result = new Value();
@@ -2049,6 +2113,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithBody<CreateSynonym>(body);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=CreateSynonym");
                 result = restRequest.As<Synonym>().Result;
                 if(result == null)
                     result = new Synonym();
@@ -2107,6 +2173,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=DeleteSynonym");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -2169,6 +2237,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("include_audit", includeAudit);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=GetSynonym");
                 result = restRequest.As<Synonym>().Result;
                 if(result == null)
                     result = new Synonym();
@@ -2243,6 +2313,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("include_audit", includeAudit);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=ListSynonyms");
                 result = restRequest.As<SynonymCollection>().Result;
                 if(result == null)
                     result = new SynonymCollection();
@@ -2305,6 +2377,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithBody<UpdateSynonym>(body);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=UpdateSynonym");
                 result = restRequest.As<Synonym>().Result;
                 if(result == null)
                     result = new Synonym();
@@ -2357,6 +2431,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithBody<CreateDialogNode>(properties);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=CreateDialogNode");
                 result = restRequest.As<DialogNode>().Result;
                 if(result == null)
                     result = new DialogNode();
@@ -2409,6 +2485,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=DeleteDialogNode");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -2465,6 +2543,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("include_audit", includeAudit);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=GetDialogNode");
                 result = restRequest.As<DialogNode>().Result;
                 if(result == null)
                     result = new DialogNode();
@@ -2533,6 +2613,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("include_audit", includeAudit);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=ListDialogNodes");
                 result = restRequest.As<DialogNodeCollection>().Result;
                 if(result == null)
                     result = new DialogNodeCollection();
@@ -2594,6 +2676,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                 restRequest.WithBody<UpdateDialogNode>(properties);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=UpdateDialogNode");
                 result = restRequest.As<DialogNode>().Result;
                 if(result == null)
                     result = new DialogNode();
@@ -2660,6 +2744,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("cursor", cursor);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=ListAllLogs");
                 result = restRequest.As<LogCollection>().Result;
                 if(result == null)
                     result = new LogCollection();
@@ -2728,6 +2814,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("cursor", cursor);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=ListLogs");
                 result = restRequest.As<LogCollection>().Result;
                 if(result == null)
                     result = new LogCollection();
@@ -2781,6 +2869,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
                     restRequest.WithArgument("customer_id", customerId);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=DeleteUserData");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();

--- a/src/IBM.WatsonDeveloperCloud.Assistant.v2/AssistantService.cs
+++ b/src/IBM.WatsonDeveloperCloud.Assistant.v2/AssistantService.cs
@@ -124,6 +124,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v2
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v2;operation_id=CreateSession");
                 result = restRequest.As<SessionResponse>().Result;
                 if(result == null)
                     result = new SessionResponse();
@@ -178,6 +180,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v2
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v2;operation_id=DeleteSession");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -236,6 +240,8 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v2
                 restRequest.WithBody<MessageRequest>(request);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v2;operation_id=Message");
                 result = restRequest.As<MessageResponse>().Result;
                 if(result == null)
                     result = new MessageResponse();

--- a/src/IBM.WatsonDeveloperCloud.CompareComply.v1/CompareComplyService.cs
+++ b/src/IBM.WatsonDeveloperCloud.CompareComply.v1/CompareComplyService.cs
@@ -119,6 +119,8 @@ namespace IBM.WatsonDeveloperCloud.CompareComply.v1
                 restRequest.WithBodyContent(formData);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=compare-comply;service_version=v1;operation_id=ConvertToHtml");
                 result = restRequest.As<HTMLReturn>().Result;
                 if(result == null)
                     result = new HTMLReturn();
@@ -176,6 +178,8 @@ namespace IBM.WatsonDeveloperCloud.CompareComply.v1
                 restRequest.WithBodyContent(formData);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=compare-comply;service_version=v1;operation_id=ClassifyElements");
                 result = restRequest.As<ClassifyReturn>().Result;
                 if(result == null)
                     result = new ClassifyReturn();
@@ -233,6 +237,8 @@ namespace IBM.WatsonDeveloperCloud.CompareComply.v1
                 restRequest.WithBodyContent(formData);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=compare-comply;service_version=v1;operation_id=ExtractTables");
                 result = restRequest.As<TableReturn>().Result;
                 if(result == null)
                     result = new TableReturn();
@@ -310,6 +316,8 @@ namespace IBM.WatsonDeveloperCloud.CompareComply.v1
                 restRequest.WithBodyContent(formData);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=compare-comply;service_version=v1;operation_id=CompareDocuments");
                 result = restRequest.As<CompareReturn>().Result;
                 if(result == null)
                     result = new CompareReturn();
@@ -352,6 +360,8 @@ namespace IBM.WatsonDeveloperCloud.CompareComply.v1
                 restRequest.WithBody<FeedbackInput>(feedbackData);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=compare-comply;service_version=v1;operation_id=AddFeedback");
                 result = restRequest.As<FeedbackReturn>().Result;
                 if(result == null)
                     result = new FeedbackReturn();
@@ -396,6 +406,8 @@ namespace IBM.WatsonDeveloperCloud.CompareComply.v1
                     restRequest.WithArgument("model_id", modelId);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=compare-comply;service_version=v1;operation_id=DeleteFeedback");
                 result = restRequest.As<FeedbackDeleted>().Result;
                 if(result == null)
                     result = new FeedbackDeleted();
@@ -439,6 +451,8 @@ namespace IBM.WatsonDeveloperCloud.CompareComply.v1
                     restRequest.WithArgument("model_id", modelId);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=compare-comply;service_version=v1;operation_id=GetFeedback");
                 result = restRequest.As<GetFeedback>().Result;
                 if(result == null)
                     result = new GetFeedback();
@@ -545,6 +559,8 @@ namespace IBM.WatsonDeveloperCloud.CompareComply.v1
                     restRequest.WithArgument("include_total", includeTotal);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=compare-comply;service_version=v1;operation_id=ListFeedback");
                 result = restRequest.As<FeedbackList>().Result;
                 if(result == null)
                     result = new FeedbackList();
@@ -670,6 +686,8 @@ namespace IBM.WatsonDeveloperCloud.CompareComply.v1
                 restRequest.WithBodyContent(formData);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=compare-comply;service_version=v1;operation_id=CreateBatch");
                 result = restRequest.As<BatchStatus>().Result;
                 if(result == null)
                     result = new BatchStatus();
@@ -709,6 +727,8 @@ namespace IBM.WatsonDeveloperCloud.CompareComply.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=compare-comply;service_version=v1;operation_id=GetBatch");
                 result = restRequest.As<BatchStatus>().Result;
                 if(result == null)
                     result = new BatchStatus();
@@ -745,6 +765,8 @@ namespace IBM.WatsonDeveloperCloud.CompareComply.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=compare-comply;service_version=v1;operation_id=ListBatches");
                 result = restRequest.As<Batches>().Result;
                 if(result == null)
                     result = new Batches();
@@ -796,6 +818,8 @@ namespace IBM.WatsonDeveloperCloud.CompareComply.v1
                     restRequest.WithArgument("model_id", modelId);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=compare-comply;service_version=v1;operation_id=UpdateBatch");
                 result = restRequest.As<BatchStatus>().Result;
                 if(result == null)
                     result = new BatchStatus();

--- a/src/IBM.WatsonDeveloperCloud.Discovery.v1/DiscoveryService.cs
+++ b/src/IBM.WatsonDeveloperCloud.Discovery.v1/DiscoveryService.cs
@@ -130,6 +130,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBody<CreateEnvironmentRequest>(body);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=CreateEnvironment");
                 result = restRequest.As<Environment>().Result;
                 if(result == null)
                     result = new Environment();
@@ -175,6 +177,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=DeleteEnvironment");
                 result = restRequest.As<DeleteEnvironmentResponse>().Result;
                 if(result == null)
                     result = new DeleteEnvironmentResponse();
@@ -220,6 +224,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=GetEnvironment");
                 result = restRequest.As<Environment>().Result;
                 if(result == null)
                     result = new Environment();
@@ -267,6 +273,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                     restRequest.WithArgument("name", name);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=ListEnvironments");
                 result = restRequest.As<ListEnvironmentsResponse>().Result;
                 if(result == null)
                     result = new ListEnvironmentsResponse();
@@ -319,6 +327,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                     restRequest.WithArgument("collection_ids", string.Join(",", collectionIds.ToArray()));
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=ListFields");
                 result = restRequest.As<ListCollectionFieldsResponse>().Result;
                 if(result == null)
                     result = new ListCollectionFieldsResponse();
@@ -371,6 +381,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBody<UpdateEnvironmentRequest>(body);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=UpdateEnvironment");
                 result = restRequest.As<Environment>().Result;
                 if(result == null)
                     result = new Environment();
@@ -442,6 +454,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBody<Configuration>(configuration);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=CreateConfiguration");
                 result = restRequest.As<Configuration>().Result;
                 if(result == null)
                     result = new Configuration();
@@ -495,6 +509,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=DeleteConfiguration");
                 result = restRequest.As<DeleteConfigurationResponse>().Result;
                 if(result == null)
                     result = new DeleteConfigurationResponse();
@@ -543,6 +559,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=GetConfiguration");
                 result = restRequest.As<Configuration>().Result;
                 if(result == null)
                     result = new Configuration();
@@ -593,6 +611,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                     restRequest.WithArgument("name", name);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=ListConfigurations");
                 result = restRequest.As<ListConfigurationsResponse>().Result;
                 if(result == null)
                     result = new ListConfigurationsResponse();
@@ -667,6 +687,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBody<Configuration>(configuration);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=UpdateConfiguration");
                 result = restRequest.As<Configuration>().Result;
                 if(result == null)
                     result = new Configuration();
@@ -765,6 +787,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBodyContent(formData);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=TestConfigurationInEnvironment");
                 result = restRequest.As<TestDocument>().Result;
                 if(result == null)
                     result = new TestDocument();
@@ -813,6 +837,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBody<CreateCollectionRequest>(body);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=CreateCollection");
                 result = restRequest.As<Collection>().Result;
                 if(result == null)
                     result = new Collection();
@@ -861,6 +887,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=DeleteCollection");
                 result = restRequest.As<DeleteCollectionResponse>().Result;
                 if(result == null)
                     result = new DeleteCollectionResponse();
@@ -909,6 +937,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=GetCollection");
                 result = restRequest.As<Collection>().Result;
                 if(result == null)
                     result = new Collection();
@@ -959,6 +989,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=ListCollectionFields");
                 result = restRequest.As<ListCollectionFieldsResponse>().Result;
                 if(result == null)
                     result = new ListCollectionFieldsResponse();
@@ -1009,6 +1041,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                     restRequest.WithArgument("name", name);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=ListCollections");
                 result = restRequest.As<ListCollectionsResponse>().Result;
                 if(result == null)
                     result = new ListCollectionsResponse();
@@ -1059,6 +1093,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBody<UpdateCollectionRequest>(body);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=UpdateCollection");
                 result = restRequest.As<Collection>().Result;
                 if(result == null)
                     result = new Collection();
@@ -1114,6 +1150,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBody<Expansions>(body);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=CreateExpansions");
                 result = restRequest.As<Expansions>().Result;
                 if(result == null)
                     result = new Expansions();
@@ -1179,6 +1217,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBodyContent(formData);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=CreateStopwordList");
                 result = restRequest.As<TokenDictStatusResponse>().Result;
                 if(result == null)
                     result = new TokenDictStatusResponse();
@@ -1232,6 +1272,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBody<TokenDict>(tokenizationDictionary);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=CreateTokenizationDictionary");
                 result = restRequest.As<TokenDictStatusResponse>().Result;
                 if(result == null)
                     result = new TokenDictStatusResponse();
@@ -1283,6 +1325,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=DeleteExpansions");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -1334,6 +1378,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=DeleteStopwordList");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -1384,6 +1430,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=DeleteTokenizationDictionary");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -1434,6 +1482,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=GetTokenizationDictionaryStatus");
                 result = restRequest.As<TokenDictStatusResponse>().Result;
                 if(result == null)
                     result = new TokenDictStatusResponse();
@@ -1485,6 +1535,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=ListExpansions");
                 result = restRequest.As<Expansions>().Result;
                 if(result == null)
                     result = new Expansions();
@@ -1582,6 +1634,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBodyContent(formData);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=AddDocument");
                 result = restRequest.As<DocumentAccepted>().Result;
                 if(result == null)
                     result = new DocumentAccepted();
@@ -1636,6 +1690,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=DeleteDocument");
                 result = restRequest.As<DeleteDocumentResponse>().Result;
                 if(result == null)
                     result = new DeleteDocumentResponse();
@@ -1691,6 +1747,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=GetDocumentStatus");
                 result = restRequest.As<DocumentStatus>().Result;
                 if(result == null)
                     result = new DocumentStatus();
@@ -1773,6 +1831,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBodyContent(formData);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=UpdateDocument");
                 result = restRequest.As<DocumentAccepted>().Result;
                 if(result == null)
                     result = new DocumentAccepted();
@@ -1910,6 +1970,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=FederatedQuery");
                 result = restRequest.As<QueryResponse>().Result;
                 if(result == null)
                     result = new QueryResponse();
@@ -2027,6 +2089,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                     restRequest.WithArgument("similar.fields", string.Join(",", similarFields.ToArray()));
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=FederatedQueryNotices");
                 result = restRequest.As<QueryNoticesResponse>().Result;
                 if(result == null)
                     result = new QueryNoticesResponse();
@@ -2166,6 +2230,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=Query");
                 result = restRequest.As<QueryResponse>().Result;
                 if(result == null)
                     result = new QueryResponse();
@@ -2222,6 +2288,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBody<QueryEntities>(entityQuery);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=QueryEntities");
                 result = restRequest.As<QueryEntitiesResponse>().Result;
                 if(result == null)
                     result = new QueryEntitiesResponse();
@@ -2353,6 +2421,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                     restRequest.WithArgument("similar.fields", string.Join(",", similarFields.ToArray()));
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=QueryNotices");
                 result = restRequest.As<QueryNoticesResponse>().Result;
                 if(result == null)
                     result = new QueryNoticesResponse();
@@ -2409,6 +2479,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBody<QueryRelations>(relationshipQuery);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=QueryRelations");
                 result = restRequest.As<QueryRelationsResponse>().Result;
                 if(result == null)
                     result = new QueryRelationsResponse();
@@ -2464,6 +2536,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBody<NewTrainingQuery>(body);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=AddTrainingData");
                 result = restRequest.As<TrainingQuery>().Result;
                 if(result == null)
                     result = new TrainingQuery();
@@ -2521,6 +2595,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBody<TrainingExample>(body);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=CreateTrainingExample");
                 result = restRequest.As<TrainingExample>().Result;
                 if(result == null)
                     result = new TrainingExample();
@@ -2571,6 +2647,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=DeleteAllTrainingData");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -2624,6 +2702,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=DeleteTrainingData");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -2680,6 +2760,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=DeleteTrainingExample");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -2733,6 +2815,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=GetTrainingData");
                 result = restRequest.As<TrainingQuery>().Result;
                 if(result == null)
                     result = new TrainingQuery();
@@ -2789,6 +2873,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=GetTrainingExample");
                 result = restRequest.As<TrainingExample>().Result;
                 if(result == null)
                     result = new TrainingExample();
@@ -2839,6 +2925,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=ListTrainingData");
                 result = restRequest.As<TrainingDataSet>().Result;
                 if(result == null)
                     result = new TrainingDataSet();
@@ -2892,6 +2980,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=ListTrainingExamples");
                 result = restRequest.As<TrainingExampleList>().Result;
                 if(result == null)
                     result = new TrainingExampleList();
@@ -2952,6 +3042,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBody<TrainingExamplePatch>(body);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=UpdateTrainingExample");
                 result = restRequest.As<TrainingExample>().Result;
                 if(result == null)
                     result = new TrainingExample();
@@ -3005,6 +3097,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                     restRequest.WithArgument("customer_id", customerId);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=DeleteUserData");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -3053,6 +3147,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBody<CreateEventObject>(queryEvent);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=CreateEvent");
                 result = restRequest.As<CreateEventResponse>().Result;
                 if(result == null)
                     result = new CreateEventResponse();
@@ -3110,6 +3206,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                     restRequest.WithArgument("result_type", resultType);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=GetMetricsEventRate");
                 result = restRequest.As<MetricResponse>().Result;
                 if(result == null)
                     result = new MetricResponse();
@@ -3165,6 +3263,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                     restRequest.WithArgument("result_type", resultType);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=GetMetricsQuery");
                 result = restRequest.As<MetricResponse>().Result;
                 if(result == null)
                     result = new MetricResponse();
@@ -3222,6 +3322,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                     restRequest.WithArgument("result_type", resultType);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=GetMetricsQueryEvent");
                 result = restRequest.As<MetricResponse>().Result;
                 if(result == null)
                     result = new MetricResponse();
@@ -3278,6 +3380,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                     restRequest.WithArgument("result_type", resultType);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=GetMetricsQueryNoResults");
                 result = restRequest.As<MetricResponse>().Result;
                 if(result == null)
                     result = new MetricResponse();
@@ -3327,6 +3431,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                     restRequest.WithArgument("count", count);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=GetMetricsQueryTokenEvent");
                 result = restRequest.As<MetricTokenResponse>().Result;
                 if(result == null)
                     result = new MetricTokenResponse();
@@ -3395,6 +3501,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                     restRequest.WithArgument("sort", string.Join(",", sort.ToArray()));
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=QueryLog");
                 result = restRequest.As<LogQueryResponse>().Result;
                 if(result == null)
                     result = new LogQueryResponse();
@@ -3448,6 +3556,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBody<Credentials>(credentialsParameter);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=CreateCredentials");
                 result = restRequest.As<Credentials>().Result;
                 if(result == null)
                     result = new Credentials();
@@ -3498,6 +3608,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=DeleteCredentials");
                 result = restRequest.As<DeleteCredentials>().Result;
                 if(result == null)
                     result = new DeleteCredentials();
@@ -3551,6 +3663,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=GetCredentials");
                 result = restRequest.As<Credentials>().Result;
                 if(result == null)
                     result = new Credentials();
@@ -3600,6 +3714,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=ListCredentials");
                 result = restRequest.As<CredentialsList>().Result;
                 if(result == null)
                     result = new CredentialsList();
@@ -3656,6 +3772,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBody<Credentials>(credentialsParameter);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=UpdateCredentials");
                 result = restRequest.As<Credentials>().Result;
                 if(result == null)
                     result = new Credentials();
@@ -3704,6 +3822,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithBody<GatewayName>(gatewayName);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=CreateGateway");
                 result = restRequest.As<Gateway>().Result;
                 if(result == null)
                     result = new Gateway();
@@ -3754,6 +3874,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=DeleteGateway");
                 result = restRequest.As<GatewayDelete>().Result;
                 if(result == null)
                     result = new GatewayDelete();
@@ -3804,6 +3926,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=GetGateway");
                 result = restRequest.As<Gateway>().Result;
                 if(result == null)
                     result = new Gateway();
@@ -3851,6 +3975,8 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=ListGateways");
                 result = restRequest.As<GatewayList>().Result;
                 if(result == null)
                     result = new GatewayList();

--- a/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/LanguageTranslatorService.cs
+++ b/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/LanguageTranslatorService.cs
@@ -125,6 +125,8 @@ namespace IBM.WatsonDeveloperCloud.LanguageTranslator.v3
                 restRequest.WithBody<TranslateRequest>(request);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=language_translator;service_version=v3;operation_id=Translate");
                 result = restRequest.As<TranslationResult>().Result;
                 if(result == null)
                     result = new TranslationResult();
@@ -172,6 +174,8 @@ namespace IBM.WatsonDeveloperCloud.LanguageTranslator.v3
                 restRequest.WithBodyContent(new StringContent(text, Encoding.UTF8, HttpMediaType.TEXT_PLAIN));
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=language_translator;service_version=v3;operation_id=Identify");
                 result = restRequest.As<IdentifiedLanguages>().Result;
                 if(result == null)
                     result = new IdentifiedLanguages();
@@ -217,6 +221,8 @@ namespace IBM.WatsonDeveloperCloud.LanguageTranslator.v3
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=language_translator;service_version=v3;operation_id=ListIdentifiableLanguages");
                 result = restRequest.As<IdentifiableLanguages>().Result;
                 if(result == null)
                     result = new IdentifiableLanguages();
@@ -312,6 +318,8 @@ namespace IBM.WatsonDeveloperCloud.LanguageTranslator.v3
                 restRequest.WithBodyContent(formData);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=language_translator;service_version=v3;operation_id=CreateModel");
                 result = restRequest.As<TranslationModel>().Result;
                 if(result == null)
                     result = new TranslationModel();
@@ -359,6 +367,8 @@ namespace IBM.WatsonDeveloperCloud.LanguageTranslator.v3
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=language_translator;service_version=v3;operation_id=DeleteModel");
                 result = restRequest.As<DeleteModelResult>().Result;
                 if(result == null)
                     result = new DeleteModelResult();
@@ -408,6 +418,8 @@ namespace IBM.WatsonDeveloperCloud.LanguageTranslator.v3
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=language_translator;service_version=v3;operation_id=GetModel");
                 result = restRequest.As<TranslationModel>().Result;
                 if(result == null)
                     result = new TranslationModel();
@@ -464,6 +476,8 @@ namespace IBM.WatsonDeveloperCloud.LanguageTranslator.v3
                     restRequest.WithArgument("default", defaultModels);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=language_translator;service_version=v3;operation_id=ListModels");
                 result = restRequest.As<TranslationModels>().Result;
                 if(result == null)
                     result = new TranslationModels();

--- a/src/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1/NaturalLanguageClassifierService.cs
+++ b/src/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1/NaturalLanguageClassifierService.cs
@@ -106,6 +106,8 @@ namespace IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1
                 restRequest.WithBody<ClassifyInput>(body);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=natural_language_classifier;service_version=v1;operation_id=Classify");
                 result = restRequest.As<Classification>().Result;
                 if(result == null)
                     result = new Classification();
@@ -155,6 +157,8 @@ namespace IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1
                 restRequest.WithBody<ClassifyCollectionInput>(body);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=natural_language_classifier;service_version=v1;operation_id=ClassifyCollection");
                 result = restRequest.As<ClassificationCollection>().Result;
                 if(result == null)
                     result = new ClassificationCollection();
@@ -227,6 +231,8 @@ namespace IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1
                 restRequest.WithBodyContent(formData);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=natural_language_classifier;service_version=v1;operation_id=CreateClassifier");
                 result = restRequest.As<Classifier>().Result;
                 if(result == null)
                     result = new Classifier();
@@ -267,6 +273,8 @@ namespace IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=natural_language_classifier;service_version=v1;operation_id=DeleteClassifier");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -309,6 +317,8 @@ namespace IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=natural_language_classifier;service_version=v1;operation_id=GetClassifier");
                 result = restRequest.As<Classifier>().Result;
                 if(result == null)
                     result = new Classifier();
@@ -348,6 +358,8 @@ namespace IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=natural_language_classifier;service_version=v1;operation_id=ListClassifiers");
                 result = restRequest.As<ClassifierList>().Result;
                 if(result == null)
                     result = new ClassifierList();

--- a/src/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1/NaturalLanguageUnderstandingService.cs
+++ b/src/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1/NaturalLanguageUnderstandingService.cs
@@ -130,6 +130,8 @@ namespace IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1
                 restRequest.WithBody<Parameters>(parameters);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=natural-language-understanding;service_version=v1;operation_id=Analyze");
                 result = restRequest.As<AnalysisResults>().Result;
                 if(result == null)
                     result = new AnalysisResults();
@@ -176,6 +178,8 @@ namespace IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=natural-language-understanding;service_version=v1;operation_id=DeleteModel");
                 result = restRequest.As<InlineResponse200>().Result;
                 if(result == null)
                     result = new InlineResponse200();
@@ -222,6 +226,8 @@ namespace IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=natural-language-understanding;service_version=v1;operation_id=ListModels");
                 result = restRequest.As<ListModelsResults>().Result;
                 if(result == null)
                     result = new ListModelsResults();

--- a/src/IBM.WatsonDeveloperCloud.PersonalityInsights.v3/PersonalityInsightsService.cs
+++ b/src/IBM.WatsonDeveloperCloud.PersonalityInsights.v3/PersonalityInsightsService.cs
@@ -192,6 +192,8 @@ namespace IBM.WatsonDeveloperCloud.PersonalityInsights.v3
                 restRequest.WithBody<Content>(content);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=personality_insights;service_version=v3;operation_id=Profile");
                 result = restRequest.As<Profile>().Result;
                 if(result == null)
                     result = new Profile();
@@ -312,6 +314,8 @@ namespace IBM.WatsonDeveloperCloud.PersonalityInsights.v3
                 restRequest.WithBody<Content>(content);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=personality_insights;service_version=v3;operation_id=ProfileAsCsv");
                 result = new System.IO.MemoryStream(restRequest.AsByteArray().Result);
             }
             catch(AggregateException ae)

--- a/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/SpeechToTextService.cs
+++ b/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/SpeechToTextService.cs
@@ -106,6 +106,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=GetModel");
                 result = restRequest.As<SpeechModel>().Result;
                 if(result == null)
                     result = new SpeechModel();
@@ -148,6 +150,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=ListModels");
                 result = restRequest.As<SpeechModels>().Result;
                 if(result == null)
                     result = new SpeechModels();
@@ -422,6 +426,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=Recognize");
                 result = restRequest.As<SpeechRecognitionResults>().Result;
                 if(result == null)
                     result = new SpeechRecognitionResults();
@@ -475,6 +481,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=CheckJob");
                 result = restRequest.As<RecognitionJob>().Result;
                 if(result == null)
                     result = new RecognitionJob();
@@ -522,6 +530,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=CheckJobs");
                 result = restRequest.As<RecognitionJobs>().Result;
                 if(result == null)
                     result = new RecognitionJobs();
@@ -844,6 +854,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=CreateJob");
                 result = restRequest.As<RecognitionJob>().Result;
                 if(result == null)
                     result = new RecognitionJob();
@@ -892,6 +904,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=DeleteJob");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -972,6 +986,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                     restRequest.WithArgument("user_secret", userSecret);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=RegisterCallback");
                 result = restRequest.As<RegisterStatus>().Result;
                 if(result == null)
                     result = new RegisterStatus();
@@ -1021,6 +1037,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                     restRequest.WithArgument("callback_url", callbackUrl);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=UnregisterCallback");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -1069,6 +1087,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                 restRequest.WithBody<CreateLanguageModel>(createLanguageModel);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=CreateLanguageModel");
                 result = restRequest.As<LanguageModel>().Result;
                 if(result == null)
                     result = new LanguageModel();
@@ -1118,6 +1138,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=DeleteLanguageModel");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -1166,6 +1188,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=GetLanguageModel");
                 result = restRequest.As<LanguageModel>().Result;
                 if(result == null)
                     result = new LanguageModel();
@@ -1216,6 +1240,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                     restRequest.WithArgument("language", language);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=ListLanguageModels");
                 result = restRequest.As<LanguageModels>().Result;
                 if(result == null)
                     result = new LanguageModels();
@@ -1266,6 +1292,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=ResetLanguageModel");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -1357,6 +1385,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                     restRequest.WithArgument("customization_weight", customizationWeight);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=TrainLanguageModel");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -1415,6 +1445,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=UpgradeLanguageModel");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -1531,6 +1563,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                 restRequest.WithBodyContent(formData);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=AddCorpus");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -1586,6 +1620,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=DeleteCorpus");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -1638,6 +1674,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=GetCorpus");
                 result = restRequest.As<Corpus>().Result;
                 if(result == null)
                     result = new Corpus();
@@ -1687,6 +1725,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=ListCorpora");
                 result = restRequest.As<Corpora>().Result;
                 if(result == null)
                     result = new Corpora();
@@ -1770,6 +1810,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                 restRequest.WithBody<CustomWord>(customWord);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=AddWord");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -1863,6 +1905,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                 restRequest.WithBody<CustomWords>(customWords);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=AddWords");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -1920,6 +1964,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=DeleteWord");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -1973,6 +2019,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=GetWord");
                 result = restRequest.As<Word>().Result;
                 if(result == null)
                     result = new Word();
@@ -2040,6 +2088,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                     restRequest.WithArgument("sort", sort);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=ListWords");
                 result = restRequest.As<Words>().Result;
                 if(result == null)
                     result = new Words();
@@ -2148,6 +2198,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=AddGrammar");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -2203,6 +2255,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=DeleteGrammar");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -2255,6 +2309,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=GetGrammar");
                 result = restRequest.As<Grammar>().Result;
                 if(result == null)
                     result = new Grammar();
@@ -2304,6 +2360,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=ListGrammars");
                 result = restRequest.As<Grammars>().Result;
                 if(result == null)
                     result = new Grammars();
@@ -2352,6 +2410,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                 restRequest.WithBody<CreateAcousticModel>(createAcousticModel);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=CreateAcousticModel");
                 result = restRequest.As<AcousticModel>().Result;
                 if(result == null)
                     result = new AcousticModel();
@@ -2401,6 +2461,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=DeleteAcousticModel");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -2449,6 +2511,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=GetAcousticModel");
                 result = restRequest.As<AcousticModel>().Result;
                 if(result == null)
                     result = new AcousticModel();
@@ -2499,6 +2563,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                     restRequest.WithArgument("language", language);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=ListAcousticModels");
                 result = restRequest.As<AcousticModels>().Result;
                 if(result == null)
                     result = new AcousticModels();
@@ -2549,6 +2615,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=ResetAcousticModel");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -2630,6 +2698,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                     restRequest.WithArgument("custom_language_model_id", customLanguageModelId);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=TrainAcousticModel");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -2699,6 +2769,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                     restRequest.WithArgument("custom_language_model_id", customLanguageModelId);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=UpgradeAcousticModel");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -2862,6 +2934,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=AddAudio");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -2916,6 +2990,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=DeleteAudio");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -2981,6 +3057,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=GetAudio");
                 result = restRequest.As<AudioListing>().Result;
                 if(result == null)
                     result = new AudioListing();
@@ -3032,6 +3110,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=ListAudio");
                 result = restRequest.As<AudioResources>().Result;
                 if(result == null)
                     result = new AudioResources();
@@ -3084,6 +3164,8 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                     restRequest.WithArgument("customer_id", customerId);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=DeleteUserData");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();

--- a/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/SpeechToTextServiceExtension.cs
+++ b/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/SpeechToTextServiceExtension.cs
@@ -126,6 +126,7 @@ namespace IBM.WatsonDeveloperCloud.SpeechToText.v1
                     bodyContent.Headers.Add("Content-Type", contentType);
 
                 restRequest.WithBodyContent(bodyContent);
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=Recognize");
 
                 result = restRequest.As<SpeechRecognitionResults>()
                            .Result;

--- a/src/IBM.WatsonDeveloperCloud.TextToSpeech.v1/TextToSpeechService.cs
+++ b/src/IBM.WatsonDeveloperCloud.TextToSpeech.v1/TextToSpeechService.cs
@@ -108,6 +108,8 @@ namespace IBM.WatsonDeveloperCloud.TextToSpeech.v1
                     restRequest.WithArgument("customization_id", customizationId);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=GetVoice");
                 result = restRequest.As<Voice>().Result;
                 if(result == null)
                     result = new Voice();
@@ -151,6 +153,8 @@ namespace IBM.WatsonDeveloperCloud.TextToSpeech.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=ListVoices");
                 result = restRequest.As<Voices>().Result;
                 if(result == null)
                     result = new Voices();
@@ -287,6 +291,8 @@ namespace IBM.WatsonDeveloperCloud.TextToSpeech.v1
                 restRequest.WithBody<Text>(text);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=Synthesize");
                 result = new System.IO.MemoryStream(restRequest.AsByteArray().Result);
             }
             catch(AggregateException ae)
@@ -351,6 +357,8 @@ namespace IBM.WatsonDeveloperCloud.TextToSpeech.v1
                     restRequest.WithArgument("customization_id", customizationId);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=GetPronunciation");
                 result = restRequest.As<Pronunciation>().Result;
                 if(result == null)
                     result = new Pronunciation();
@@ -401,6 +409,8 @@ namespace IBM.WatsonDeveloperCloud.TextToSpeech.v1
                 restRequest.WithBody<CreateVoiceModel>(createVoiceModel);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=CreateVoiceModel");
                 result = restRequest.As<VoiceModel>().Result;
                 if(result == null)
                     result = new VoiceModel();
@@ -450,6 +460,8 @@ namespace IBM.WatsonDeveloperCloud.TextToSpeech.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=DeleteVoiceModel");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -500,6 +512,8 @@ namespace IBM.WatsonDeveloperCloud.TextToSpeech.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=GetVoiceModel");
                 result = restRequest.As<VoiceModel>().Result;
                 if(result == null)
                     result = new VoiceModel();
@@ -552,6 +566,8 @@ namespace IBM.WatsonDeveloperCloud.TextToSpeech.v1
                     restRequest.WithArgument("language", language);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=ListVoiceModels");
                 result = restRequest.As<VoiceModels>().Result;
                 if(result == null)
                     result = new VoiceModels();
@@ -624,6 +640,8 @@ namespace IBM.WatsonDeveloperCloud.TextToSpeech.v1
                 restRequest.WithBody<UpdateVoiceModel>(updateVoiceModel);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=UpdateVoiceModel");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -696,6 +714,8 @@ namespace IBM.WatsonDeveloperCloud.TextToSpeech.v1
                 restRequest.WithBody<Translation>(translation);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=AddWord");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -767,6 +787,8 @@ namespace IBM.WatsonDeveloperCloud.TextToSpeech.v1
                 restRequest.WithBody<Words>(customWords);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=AddWords");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -819,6 +841,8 @@ namespace IBM.WatsonDeveloperCloud.TextToSpeech.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=DeleteWord");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();
@@ -872,6 +896,8 @@ namespace IBM.WatsonDeveloperCloud.TextToSpeech.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=GetWord");
                 result = restRequest.As<Translation>().Result;
                 if(result == null)
                     result = new Translation();
@@ -922,6 +948,8 @@ namespace IBM.WatsonDeveloperCloud.TextToSpeech.v1
 
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=ListWords");
                 result = restRequest.As<Words>().Result;
                 if(result == null)
                     result = new Words();
@@ -974,6 +1002,8 @@ namespace IBM.WatsonDeveloperCloud.TextToSpeech.v1
                     restRequest.WithArgument("customer_id", customerId);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=DeleteUserData");
                 result = restRequest.As<BaseModel>().Result;
                 if(result == null)
                     result = new BaseModel();

--- a/src/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3/ToneAnalyzerService.cs
+++ b/src/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3/ToneAnalyzerService.cs
@@ -167,6 +167,8 @@ namespace IBM.WatsonDeveloperCloud.ToneAnalyzer.v3
                 restRequest.WithBody<ToneInput>(toneInput);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=tone_analyzer;service_version=v3;operation_id=Tone");
                 result = restRequest.As<ToneAnalysis>().Result;
                 if(result == null)
                     result = new ToneAnalysis();
@@ -239,6 +241,8 @@ namespace IBM.WatsonDeveloperCloud.ToneAnalyzer.v3
                 restRequest.WithBody<ToneChatInput>(utterances);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=tone_analyzer;service_version=v3;operation_id=ToneChat");
                 result = restRequest.As<UtteranceAnalyses>().Result;
                 if(result == null)
                     result = new UtteranceAnalyses();

--- a/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/VisualRecognitionService.cs
+++ b/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/VisualRecognitionService.cs
@@ -180,6 +180,8 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3
                 restRequest.WithBodyContent(formData);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=watson_vision_combined;service_version=v3;operation_id=Classify");
                 result = restRequest.As<ClassifiedImages>().Result;
                 if (result == null)
                     result = new ClassifiedImages();
@@ -269,6 +271,8 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3
                 restRequest.WithBodyContent(formData);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=watson_vision_combined;service_version=v3;operation_id=DetectFaces");
                 result = restRequest.As<DetectedFaces>().Result;
                 if (result == null)
                     result = new DetectedFaces();
@@ -314,6 +318,8 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=watson_vision_combined;service_version=v3;operation_id=DeleteClassifier");
                 result = restRequest.As<BaseModel>().Result;
                 if (result == null)
                     result = new BaseModel();
@@ -361,6 +367,8 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3
                 restRequest.WithArgument("version", VersionDate);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=watson_vision_combined;service_version=v3;operation_id=GetClassifier");
                 result = restRequest.As<Classifier>().Result;
                 if (result == null)
                     result = new Classifier();
@@ -407,6 +415,8 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3
                     restRequest.WithArgument("verbose", verbose);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=watson_vision_combined;service_version=v3;operation_id=ListClassifiers");
                 result = restRequest.As<Classifiers>().Result;
                 if (result == null)
                     result = new Classifiers();
@@ -461,6 +471,8 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3
                     restRequest.WithArgument("customer_id", customerId);
                 if (customData != null)
                     restRequest.WithCustomData(customData);
+        
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=watson_vision_combined;service_version=v3;operation_id=DeleteUserData");
                 result = restRequest.As<BaseModel>().Result;
                 if (result == null)
                     result = new BaseModel();

--- a/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/VisualRecognitionServiceExtension.cs
+++ b/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/VisualRecognitionServiceExtension.cs
@@ -112,6 +112,7 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3
                 if (customData != null)
                     restRequest.WithCustomData(customData);
                 restRequest.WithFormatter(new MediaTypeHeaderValue("application/octet-stream"));
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=watson_vision_combined;service_version=v3;operation_id=CreateClassifier");
                 result = restRequest.As<Classifier>().Result;
                 if (result == null)
                     result = new Classifier();
@@ -186,6 +187,7 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3
                 if (customData != null)
                     restRequest.WithCustomData(customData);
                 restRequest.WithFormatter(new MediaTypeHeaderValue("application/octet-stream"));
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=watson_vision_combined;service_version=v3;operation_id=UpdateClassifier");
                 result = restRequest.As<Classifier>().Result;
                 if (result == null)
                     result = new Classifier();
@@ -231,6 +233,7 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3
                 if (customData != null)
                     restRequest.WithCustomData(customData);
                 restRequest.WithFormatter(new MediaTypeHeaderValue("application/octet-stream"));
+                restRequest.WithHeader("X-IBMCloud-SDK-Analytics", "service_name=watson_vision_combined;service_version=v3;operation_id=GetCoreMlModel");
                 result = restRequest.AsStream();
             }
             catch (AggregateException ae)

--- a/src/IBM.WatsonDeveloperCloud/Constants.cs
+++ b/src/IBM.WatsonDeveloperCloud/Constants.cs
@@ -26,7 +26,7 @@ namespace IBM.WatsonDeveloperCloud
         /// The version number for this SDK build. Added to the header in 
         /// each request as `User-Agent`.
         /// </summary>
-        public static readonly string SDK_VERSION = "watson-apis-dotnet-sdk/2.13.0";
+        public static readonly string SDK_VERSION = "watson-apis-dotnet-sdk-2.13.0";
         /// <summary>
         /// A constant used to access custom request headers in the dynamic
         /// customData object.

--- a/src/IBM.WatsonDeveloperCloud/Http/HttpFactory.cs
+++ b/src/IBM.WatsonDeveloperCloud/Http/HttpFactory.cs
@@ -45,7 +45,13 @@ namespace IBM.WatsonDeveloperCloud.Http
 
             // add default headers
             request.Headers.Add("accept", formatters.SelectMany(p => p.SupportedMediaTypes).Select(p => p.MediaType));
-            request.Headers.Add("User-Agent", Constants.SDK_VERSION);
+            request.Headers.Add("User-Agent", 
+                string.Format(
+                    "{0} {1} {2}", 
+                    Constants.SDK_VERSION, 
+                    System.Runtime.InteropServices.RuntimeInformation.OSDescription, 
+                    System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription
+                ));
 
             return request;
         }

--- a/src/IBM.WatsonDeveloperCloud/Http/HttpFactory.cs
+++ b/src/IBM.WatsonDeveloperCloud/Http/HttpFactory.cs
@@ -55,7 +55,7 @@ namespace IBM.WatsonDeveloperCloud.Http
                     Constants.SDK_VERSION, 
                     os,
                     osVersion,
-                    System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.Replace(" ", "-")
+                    System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.Replace(" ", "")
                 ));
 
             return request;

--- a/src/IBM.WatsonDeveloperCloud/Http/HttpFactory.cs
+++ b/src/IBM.WatsonDeveloperCloud/Http/HttpFactory.cs
@@ -45,12 +45,17 @@ namespace IBM.WatsonDeveloperCloud.Http
 
             // add default headers
             request.Headers.Add("accept", formatters.SelectMany(p => p.SupportedMediaTypes).Select(p => p.MediaType));
+            string osInfo = System.Runtime.InteropServices.RuntimeInformation.OSDescription;
+            int versionIndex = osInfo.IndexOfAny("0123456789".ToCharArray());
+            string os = osInfo.Substring(0, versionIndex).Replace(" ", "");
+            string osVersion = osInfo.Substring(versionIndex).Replace(" ", "");
             request.Headers.Add("User-Agent", 
                 string.Format(
-                    "{0} {1} {2}", 
+                    "{0} {1} {2} {3}", 
                     Constants.SDK_VERSION, 
-                    System.Runtime.InteropServices.RuntimeInformation.OSDescription, 
-                    System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription
+                    os,
+                    osVersion,
+                    System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.Replace(" ", "-")
                 ));
 
             return request;


### PR DESCRIPTION
### Summary
This pull request adds environment info to the user-agent header. I also added `X-IBMCloud-SDK-Analytics` header to each operation.

`User-Agent` `watson-apis-dotnet-sdk-2.13.0 MicrosoftWindows 10.0.17134 .NETCore4.6.25211.02`