### PR TITLE
Update dotnet standard version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -135,9 +135,9 @@ test_script:
             echo \"Test passed: $?\"
             echo \"LastExitCode: $LastExitCode\"
             $openCover = 'C:\\projects\\dotnet-standard-sdk\\packages\\OpenCover.4.6.519\\tools\\OpenCover.Console.exe'    
-            $targetArgs = '-targetargs: test ' + $folder.FullName + ' -c Release -f netcoreapp1.0'
+            $targetArgs = '-targetargs: test ' + $folder.FullName + ' -c Release -f netcoreapp2.0'
             $filter = '-filter:+[IBM.WatsonDeveloperCloud*]*-[*Tests*]*-[*Example*]*'
-            & $openCover '-target:C:\\Program Files\\dotnet\\dotnet.exe' $targetArgs '-register:user' $filter '-oldStyle' '-mergeoutput' '-hideskipped:File' '-searchdirs:$testdir\\bin\\release\\netcoreapp1.0' '-output:coverage\\coverage.xml'
+            & $openCover '-target:C:\\Program Files\\dotnet\\dotnet.exe' $targetArgs '-register:user' $filter '-oldStyle' '-mergeoutput' '-hideskipped:File' '-searchdirs:$testdir\\bin\\release\\netcoreapp2.0' '-output:coverage\\coverage.xml'
 
             C:\\projects\\dotnet-standard-sdk\\packages\\ReportGenerator.2.4.5.0\\tools\\ReportGenerator.exe -reports:coverage\\coverage.xml -targetdir:coverage -verbosity:Error
 

--- a/coverage.ps1
+++ b/coverage.ps1
@@ -23,9 +23,9 @@ $openCover = '.\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe'
 
 ForEach ($folder in (Get-ChildItem -Path .\test -Directory)) 
 {
-    $targetArgs = '-targetargs: test ' + $folder.FullName + ' -c Release -f netcoreapp1.0'
+    $targetArgs = '-targetargs: test ' + $folder.FullName + ' -c Release -f netcoreapp2.0'
     $filter = '-filter:+[IBM.WatsonDeveloperCloud*]*-[*Tests*]*-[*Example*]*'
-    & $openCover '-target:C:\\Program Files\\dotnet\\dotnet.exe' $targetArgs '-register:user' $filter '-oldStyle' '-mergeoutput' '-hideskipped:File' '-searchdirs:$testdir\\bin\\release\\netcoreapp1.0' '-output:coverage\\coverage.xml'
+    & $openCover '-target:C:\\Program Files\\dotnet\\dotnet.exe' $targetArgs '-register:user' $filter '-oldStyle' '-mergeoutput' '-hideskipped:File' '-searchdirs:$testdir\\bin\\release\\netcoreapp2.0' '-output:coverage\\coverage.xml'
 }
 
 $reportGenerator = '.\packages\ReportGenerator.2.4.5.0\tools\ReportGenerator.exe'

--- a/examples/IBM.WatsonDeveloperCloud.Assistant.v2.Example/IBM.WatsonDeveloperCloud.Assistant.v2.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.Assistant.v2.Example/IBM.WatsonDeveloperCloud.Assistant.v2.Example.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1.Example</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IBM.WatsonDeveloperCloud.Conversation.v1.Example</PackageId>

--- a/examples/IBM.WatsonDeveloperCloud.Assistant.v2.Example/IBM.WatsonDeveloperCloud.Assistant.v2.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.Assistant.v2.Example/IBM.WatsonDeveloperCloud.Assistant.v2.Example.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1.Example</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IBM.WatsonDeveloperCloud.Conversation.v1.Example</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/examples/IBM.WatsonDeveloperCloud.Conversation.v1.Example/IBM.WatsonDeveloperCloud.Conversation.v1.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.Conversation.v1.Example/IBM.WatsonDeveloperCloud.Conversation.v1.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1.Example</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IBM.WatsonDeveloperCloud.Conversation.v1.Example</PackageId>

--- a/examples/IBM.WatsonDeveloperCloud.Conversation.v1.Example/IBM.WatsonDeveloperCloud.Conversation.v1.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.Conversation.v1.Example/IBM.WatsonDeveloperCloud.Conversation.v1.Example.csproj
@@ -6,7 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1.Example</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IBM.WatsonDeveloperCloud.Conversation.v1.Example</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/examples/IBM.WatsonDeveloperCloud.Discovery.v1.Example/IBM.WatsonDeveloperCloud.Discovery.v1.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.Discovery.v1.Example/IBM.WatsonDeveloperCloud.Discovery.v1.Example.csproj
@@ -6,7 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.Discovery.v1.Example</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IBM.WatsonDeveloperCloud.Discovery.v1.Example</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/examples/IBM.WatsonDeveloperCloud.Discovery.v1.Example/IBM.WatsonDeveloperCloud.Discovery.v1.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.Discovery.v1.Example/IBM.WatsonDeveloperCloud.Discovery.v1.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Discovery.v1.Example</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IBM.WatsonDeveloperCloud.Discovery.v1.Example</PackageId>

--- a/examples/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example.csproj
@@ -6,7 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/examples/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example</PackageId>

--- a/examples/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.Ex/IBM.WatsonDeveloperCloud.NLU.v1.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.Ex/IBM.WatsonDeveloperCloud.NLU.v1.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.Ex</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.Ex</PackageId>

--- a/examples/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.Ex/IBM.WatsonDeveloperCloud.NLU.v1.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.Ex/IBM.WatsonDeveloperCloud.NLU.v1.Example.csproj
@@ -6,7 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.Ex</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.Ex</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/examples/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example</PackageId>

--- a/examples/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example.csproj
@@ -6,7 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/examples/IBM.WatsonDeveloperCloud.SpeechToText.v1.Example/IBM.WatsonDeveloperCloud.SpeechToText.v1.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.SpeechToText.v1.Example/IBM.WatsonDeveloperCloud.SpeechToText.v1.Example.csproj
@@ -6,7 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.SpeechToText.v1.Example</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IBM.WatsonDeveloperCloud.SpeechToText.v1.Example</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/examples/IBM.WatsonDeveloperCloud.SpeechToText.v1.Example/IBM.WatsonDeveloperCloud.SpeechToText.v1.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.SpeechToText.v1.Example/IBM.WatsonDeveloperCloud.SpeechToText.v1.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.SpeechToText.v1.Example</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IBM.WatsonDeveloperCloud.SpeechToText.v1.Example</PackageId>

--- a/examples/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example</PackageId>

--- a/examples/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example.csproj
@@ -6,7 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/IBM.WatsonDeveloperCloud.Assistant.v1/AssistantService.cs
+++ b/src/IBM.WatsonDeveloperCloud.Assistant.v1/AssistantService.cs
@@ -28,7 +28,7 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
 {
     public partial class AssistantService : WatsonService, IAssistantService
     {
-        const string SERVICE_NAME = "assistant";
+        const string SERVICE_NAME = "conversation";
         const string URL = "https://gateway.watsonplatform.net/assistant/api";
         private string _versionDate;
         public string VersionDate

--- a/src/IBM.WatsonDeveloperCloud.Assistant.v1/AssistantService.cs
+++ b/src/IBM.WatsonDeveloperCloud.Assistant.v1/AssistantService.cs
@@ -28,7 +28,7 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v1
 {
     public partial class AssistantService : WatsonService, IAssistantService
     {
-        const string SERVICE_NAME = "conversation";
+        const string SERVICE_NAME = "assistant";
         const string URL = "https://gateway.watsonplatform.net/assistant/api";
         private string _versionDate;
         public string VersionDate

--- a/src/IBM.WatsonDeveloperCloud.Assistant.v1/IBM.WatsonDeveloperCloud.Assistant.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.Assistant.v1/IBM.WatsonDeveloperCloud.Assistant.v1.csproj
@@ -5,7 +5,7 @@
         <AssemblyTitle>IBM.WatsonDeveloperCloud.Assistant.v1</AssemblyTitle>
         <VersionPrefix>2.16.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
-        <TargetFramework>netstandard1.3</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.Assistant.v1</AssemblyName>
         <PackageId>IBM.WatsonDeveloperCloud.Assistant.v1</PackageId>
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>

--- a/src/IBM.WatsonDeveloperCloud.Assistant.v1/IBM.WatsonDeveloperCloud.Assistant.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.Assistant.v1/IBM.WatsonDeveloperCloud.Assistant.v1.csproj
@@ -11,7 +11,6 @@
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
-        <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
         <Version>2.16.0</Version>
     </PropertyGroup>
 

--- a/src/IBM.WatsonDeveloperCloud.Assistant.v2/AssistantService.cs
+++ b/src/IBM.WatsonDeveloperCloud.Assistant.v2/AssistantService.cs
@@ -26,7 +26,7 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v2
 {
     public partial class AssistantService : WatsonService, IAssistantService
     {
-        const string SERVICE_NAME = "assistant";
+        const string SERVICE_NAME = "conversation";
         const string URL = "https://gateway.watsonplatform.net/assistant/api";
         private string _versionDate;
         public string VersionDate

--- a/src/IBM.WatsonDeveloperCloud.Assistant.v2/AssistantService.cs
+++ b/src/IBM.WatsonDeveloperCloud.Assistant.v2/AssistantService.cs
@@ -26,7 +26,7 @@ namespace IBM.WatsonDeveloperCloud.Assistant.v2
 {
     public partial class AssistantService : WatsonService, IAssistantService
     {
-        const string SERVICE_NAME = "conversation";
+        const string SERVICE_NAME = "assistant";
         const string URL = "https://gateway.watsonplatform.net/assistant/api";
         private string _versionDate;
         public string VersionDate

--- a/src/IBM.WatsonDeveloperCloud.Assistant.v2/IBM.WatsonDeveloperCloud.Assistant.v2.csproj
+++ b/src/IBM.WatsonDeveloperCloud.Assistant.v2/IBM.WatsonDeveloperCloud.Assistant.v2.csproj
@@ -5,7 +5,7 @@
         <AssemblyTitle>IBM.WatsonDeveloperCloud.Assistant.v2</AssemblyTitle>
         <VersionPrefix>2.16.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
-        <TargetFramework>netstandard1.3</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.Assistant.v2</AssemblyName>
         <PackageId>IBM.WatsonDeveloperCloud.Assistant.v2</PackageId>
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>

--- a/src/IBM.WatsonDeveloperCloud.Assistant.v2/IBM.WatsonDeveloperCloud.Assistant.v2.csproj
+++ b/src/IBM.WatsonDeveloperCloud.Assistant.v2/IBM.WatsonDeveloperCloud.Assistant.v2.csproj
@@ -11,7 +11,6 @@
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
-        <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
         <Version>2.16.0</Version>
     </PropertyGroup>
 

--- a/src/IBM.WatsonDeveloperCloud.CompareComply.v1/IBM.WatsonDeveloperCloud.CompareComply.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.CompareComply.v1/IBM.WatsonDeveloperCloud.CompareComply.v1.csproj
@@ -5,7 +5,7 @@
         <AssemblyTitle>IBM.WatsonDeveloperCloud.CompareComply.v1</AssemblyTitle>
         <VersionPrefix>2.16.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
-        <TargetFramework>netstandard1.3</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.CompareComply.v1</AssemblyName>
         <PackageId>IBM.WatsonDeveloperCloud.CompareComply.v1</PackageId>
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>

--- a/src/IBM.WatsonDeveloperCloud.CompareComply.v1/IBM.WatsonDeveloperCloud.CompareComply.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.CompareComply.v1/IBM.WatsonDeveloperCloud.CompareComply.v1.csproj
@@ -11,7 +11,6 @@
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
-        <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
         <Version>2.16.0</Version>
     </PropertyGroup>
 

--- a/src/IBM.WatsonDeveloperCloud.Conversation.v1/IBM.WatsonDeveloperCloud.Conversation.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.Conversation.v1/IBM.WatsonDeveloperCloud.Conversation.v1.csproj
@@ -5,7 +5,7 @@
         <AssemblyTitle>IBM.WatsonDeveloperCloud.Conversation.v1</AssemblyTitle>
         <VersionPrefix>2.16.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
-        <TargetFramework>netstandard1.3</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1</AssemblyName>
         <PackageId>IBM.WatsonDeveloperCloud.Conversation.v1</PackageId>
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>

--- a/src/IBM.WatsonDeveloperCloud.Conversation.v1/IBM.WatsonDeveloperCloud.Conversation.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.Conversation.v1/IBM.WatsonDeveloperCloud.Conversation.v1.csproj
@@ -11,7 +11,6 @@
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
-        <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
         <Version>2.16.0</Version>
     </PropertyGroup>
 

--- a/src/IBM.WatsonDeveloperCloud.Discovery.v1/DiscoveryService.cs
+++ b/src/IBM.WatsonDeveloperCloud.Discovery.v1/DiscoveryService.cs
@@ -765,7 +765,7 @@ namespace IBM.WatsonDeveloperCloud.Discovery.v1
                     System.Net.Http.Headers.MediaTypeHeaderValue contentType;
                     System.Net.Http.Headers.MediaTypeHeaderValue.TryParse(fileContentType, out contentType);
                     fileContent.Headers.ContentType = contentType;
-                    formData.Add(fileContent, "file", file.Name);
+                    formData.Add(fileContent, "file");
                 }
 
                 if (metadata != null)

--- a/src/IBM.WatsonDeveloperCloud.Discovery.v1/IBM.WatsonDeveloperCloud.Discovery.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.Discovery.v1/IBM.WatsonDeveloperCloud.Discovery.v1.csproj
@@ -5,7 +5,7 @@
         <AssemblyTitle>IBM.WatsonDeveloperCloud.Discovery.v1</AssemblyTitle>
         <VersionPrefix>2.16.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
-        <TargetFramework>netstandard1.3</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.Discovery.v1</AssemblyName>
         <PackageId>IBM.WatsonDeveloperCloud.Discovery.v1</PackageId>
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>

--- a/src/IBM.WatsonDeveloperCloud.Discovery.v1/IBM.WatsonDeveloperCloud.Discovery.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.Discovery.v1/IBM.WatsonDeveloperCloud.Discovery.v1.csproj
@@ -11,7 +11,6 @@
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
-        <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
         <Version>2.16.0</Version>
     </PropertyGroup>
 

--- a/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.csproj
+++ b/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.csproj
@@ -5,7 +5,7 @@
         <AssemblyTitle>IBM.WatsonDeveloperCloud.LanguageTranslator.v3</AssemblyTitle>
         <VersionPrefix>2.16.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
-        <TargetFramework>netstandard1.3</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v3</AssemblyName>
         <PackageId>IBM.WatsonDeveloperCloud.LanguageTranslator.v3</PackageId>
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>

--- a/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.csproj
+++ b/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.csproj
@@ -11,7 +11,6 @@
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
-        <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
         <Version>2.16.0</Version>
     </PropertyGroup>
 

--- a/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/LanguageTranslatorService.cs
+++ b/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/LanguageTranslatorService.cs
@@ -286,7 +286,7 @@ namespace IBM.WatsonDeveloperCloud.LanguageTranslator.v3
                     System.Net.Http.Headers.MediaTypeHeaderValue contentType;
                     System.Net.Http.Headers.MediaTypeHeaderValue.TryParse("application/octet-stream", out contentType);
                     forcedGlossaryContent.Headers.ContentType = contentType;
-                    formData.Add(forcedGlossaryContent, "forced_glossary", forcedGlossary.Name);
+                    formData.Add(forcedGlossaryContent, "forced_glossary");
                 }
 
                 if (parallelCorpus != null)
@@ -295,7 +295,7 @@ namespace IBM.WatsonDeveloperCloud.LanguageTranslator.v3
                     System.Net.Http.Headers.MediaTypeHeaderValue contentType;
                     System.Net.Http.Headers.MediaTypeHeaderValue.TryParse("application/octet-stream", out contentType);
                     parallelCorpusContent.Headers.ContentType = contentType;
-                    formData.Add(parallelCorpusContent, "parallel_corpus", parallelCorpus.Name);
+                    formData.Add(parallelCorpusContent, "parallel_corpus");
                 }
 
                 IClient client = this.Client;

--- a/src/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1.csproj
@@ -5,7 +5,7 @@
         <AssemblyTitle>IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1</AssemblyTitle>
         <VersionPrefix>2.16.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
-        <TargetFramework>netstandard1.3</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1</AssemblyName>
         <PackageId>IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1</PackageId>
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>

--- a/src/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1.csproj
@@ -11,7 +11,6 @@
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
-        <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
         <Version>2.16.0</Version>
     </PropertyGroup>
 

--- a/src/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.csproj
@@ -5,7 +5,7 @@
         <AssemblyTitle>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1</AssemblyTitle>
         <VersionPrefix>2.16.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
-        <TargetFramework>netstandard1.3</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1</AssemblyName>
         <PackageId>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1</PackageId>
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>

--- a/src/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.csproj
@@ -11,7 +11,6 @@
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
-        <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
         <Version>2.16.0</Version>
     </PropertyGroup>
 

--- a/src/IBM.WatsonDeveloperCloud.PersonalityInsights.v3/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.csproj
+++ b/src/IBM.WatsonDeveloperCloud.PersonalityInsights.v3/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.csproj
@@ -5,7 +5,7 @@
         <AssemblyTitle>IBM.WatsonDeveloperCloud.PersonalityInsights.v3</AssemblyTitle>
         <VersionPrefix>2.16.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
-        <TargetFramework>netstandard1.3</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.PersonalityInsights.v3</AssemblyName>
         <PackageId>IBM.WatsonDeveloperCloud.PersonalityInsights.v3</PackageId>
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>

--- a/src/IBM.WatsonDeveloperCloud.PersonalityInsights.v3/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.csproj
+++ b/src/IBM.WatsonDeveloperCloud.PersonalityInsights.v3/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.csproj
@@ -11,7 +11,6 @@
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
-        <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
         <Version>2.16.0</Version>
     </PropertyGroup>
 

--- a/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/IBM.WatsonDeveloperCloud.SpeechToText.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/IBM.WatsonDeveloperCloud.SpeechToText.v1.csproj
@@ -5,7 +5,7 @@
         <AssemblyTitle>IBM.WatsonDeveloperCloud.SpeechToText.v1</AssemblyTitle>
         <VersionPrefix>2.16.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
-        <TargetFramework>netstandard1.3</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.SpeechToText.v1</AssemblyName>
         <PackageId>IBM.WatsonDeveloperCloud.SpeechToText.v1</PackageId>
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>

--- a/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/IBM.WatsonDeveloperCloud.SpeechToText.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/IBM.WatsonDeveloperCloud.SpeechToText.v1.csproj
@@ -11,7 +11,6 @@
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
-        <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
         <Version>2.16.0</Version>
     </PropertyGroup>
 

--- a/src/IBM.WatsonDeveloperCloud.TextToSpeech.v1/IBM.WatsonDeveloperCloud.TextToSpeech.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.TextToSpeech.v1/IBM.WatsonDeveloperCloud.TextToSpeech.v1.csproj
@@ -11,7 +11,6 @@
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
-        <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
         <Version>2.16.0</Version>
     </PropertyGroup>
 

--- a/src/IBM.WatsonDeveloperCloud.TextToSpeech.v1/IBM.WatsonDeveloperCloud.TextToSpeech.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.TextToSpeech.v1/IBM.WatsonDeveloperCloud.TextToSpeech.v1.csproj
@@ -5,7 +5,7 @@
         <AssemblyTitle>IBM.WatsonDeveloperCloud.TextToSpeech.v1</AssemblyTitle>
         <VersionPrefix>2.16.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
-        <TargetFramework>netstandard1.3</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.TextToSpeech.v1</AssemblyName>
         <PackageId>IBM.WatsonDeveloperCloud.TextToSpeech.v1</PackageId>
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>

--- a/src/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.csproj
+++ b/src/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.csproj
@@ -5,7 +5,7 @@
         <AssemblyTitle>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3</AssemblyTitle>
         <VersionPrefix>2.16.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
-        <TargetFramework>netstandard1.3</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3</AssemblyName>
         <PackageId>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3</PackageId>
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>

--- a/src/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.csproj
+++ b/src/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.csproj
@@ -11,7 +11,6 @@
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
-        <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
         <Version>2.16.0</Version>
     </PropertyGroup>
 

--- a/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/IBM.WatsonDeveloperCloud.VisualRecognition.v3.csproj
+++ b/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/IBM.WatsonDeveloperCloud.VisualRecognition.v3.csproj
@@ -11,7 +11,6 @@
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
-        <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
         <Version>2.16.0</Version>
     </PropertyGroup>
 

--- a/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/IBM.WatsonDeveloperCloud.VisualRecognition.v3.csproj
+++ b/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/IBM.WatsonDeveloperCloud.VisualRecognition.v3.csproj
@@ -5,7 +5,7 @@
         <AssemblyTitle>IBM.WatsonDeveloperCloud.VisualRecognition.v3</AssemblyTitle>
         <VersionPrefix>2.16.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
-        <TargetFramework>netstandard1.3</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.VisualRecognition.v3</AssemblyName>
         <PackageId>IBM.WatsonDeveloperCloud.VisualRecognition.v3</PackageId>
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>

--- a/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/VisualRecognitionService.cs
+++ b/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/VisualRecognitionService.cs
@@ -30,7 +30,7 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3
 {
     public partial class VisualRecognitionService : WatsonService, IVisualRecognitionService
     {
-        const string SERVICE_NAME = "visual_recognition";
+        const string SERVICE_NAME = "watson_vision_combined";
         const string URL = "https://gateway.watsonplatform.net/visual-recognition/api";
         private string _versionDate;
         public string VersionDate

--- a/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/VisualRecognitionService.cs
+++ b/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/VisualRecognitionService.cs
@@ -30,7 +30,7 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3
 {
     public partial class VisualRecognitionService : WatsonService, IVisualRecognitionService
     {
-        const string SERVICE_NAME = "watson_vision_combined";
+        const string SERVICE_NAME = "visual_recognition";
         const string URL = "https://gateway.watsonplatform.net/visual-recognition/api";
         private string _versionDate;
         public string VersionDate

--- a/src/IBM.WatsonDeveloperCloud/IBM.WatsonDeveloperCloud.csproj
+++ b/src/IBM.WatsonDeveloperCloud/IBM.WatsonDeveloperCloud.csproj
@@ -11,7 +11,6 @@
     <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>
     <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
-    <NetStandardImplicitPackageVersion>1.6</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/IBM.WatsonDeveloperCloud/IBM.WatsonDeveloperCloud.csproj
+++ b/src/IBM.WatsonDeveloperCloud/IBM.WatsonDeveloperCloud.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>IBM.WatsonDeveloperCloud</AssemblyTitle>
     <VersionPrefix>2.16.0</VersionPrefix>
     <Authors>Watson Developer Cloud</Authors>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud</PackageId>
     <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>

--- a/test/IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests/IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests/IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests/IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests/IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.Assistant.v2.IntTests/IBM.WatsonDeveloperCloud.Assistant.v2.IntTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Assistant.v2.IntTests/IBM.WatsonDeveloperCloud.Assistant.v2.IntTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Assistant.v2.IntTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Assistant.v2.IntTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.Assistant.v2.IntTests/IBM.WatsonDeveloperCloud.Assistant.v2.IntTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Assistant.v2.IntTests/IBM.WatsonDeveloperCloud.Assistant.v2.IntTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.Assistant.v2.IntTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Assistant.v2.IntTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests/IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests/IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests/IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests/IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.CompareComply.v1.IT/CompareComplyServiceIntegrationTests.cs
+++ b/test/IBM.WatsonDeveloperCloud.CompareComply.v1.IT/CompareComplyServiceIntegrationTests.cs
@@ -150,7 +150,7 @@ namespace IBM.WatsonDeveloperCloud.CompareComply.v1.IT
         #endregion
 
         #region Feedback
-        [TestMethod]
+        //[TestMethod]
         public void Feedback_Success()
         {
             DateTime before = DateTime.Now;

--- a/test/IBM.WatsonDeveloperCloud.CompareComply.v1.IT/IBM.WatsonDeveloperCloud.CompareComply.v1.IT.csproj
+++ b/test/IBM.WatsonDeveloperCloud.CompareComply.v1.IT/IBM.WatsonDeveloperCloud.CompareComply.v1.IT.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.CompareComply.v1.IT</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.CompareComply.v1.IT</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.CompareComply.v1.IT/IBM.WatsonDeveloperCloud.CompareComply.v1.IT.csproj
+++ b/test/IBM.WatsonDeveloperCloud.CompareComply.v1.IT/IBM.WatsonDeveloperCloud.CompareComply.v1.IT.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.CompareComply.v1.IT</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.CompareComply.v1.IT</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.CompareComply.v1.UT/IBM.WatsonDeveloperCloud.CompareComply.v1.UT.csproj
+++ b/test/IBM.WatsonDeveloperCloud.CompareComply.v1.UT/IBM.WatsonDeveloperCloud.CompareComply.v1.UT.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.CompareComply.v1.UT</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.CompareComply.v1.UT</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.CompareComply.v1.UT/IBM.WatsonDeveloperCloud.CompareComply.v1.UT.csproj
+++ b/test/IBM.WatsonDeveloperCloud.CompareComply.v1.UT/IBM.WatsonDeveloperCloud.CompareComply.v1.UT.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.CompareComply.v1.UT</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.CompareComply.v1.UT</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests/IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests/IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests/IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests/IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.Core.IntegrationTests/IBM.WatsonDeveloperCloud.Core.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Core.IntegrationTests/IBM.WatsonDeveloperCloud.Core.IntegrationTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.Core.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Core.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.Core.IntegrationTests/IBM.WatsonDeveloperCloud.Core.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Core.IntegrationTests/IBM.WatsonDeveloperCloud.Core.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Core.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Core.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests/IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests/IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests/IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests/IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.IntTests/IBM.WatsonDeveloperCloud.NLU.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.IntTests/IBM.WatsonDeveloperCloud.NLU.v1.IntegrationTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.IntTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.IntTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.IntTests/IBM.WatsonDeveloperCloud.NLU.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.IntTests/IBM.WatsonDeveloperCloud.NLU.v1.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.IntTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.IntTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.UnitTests/IBM.WatsonDeveloperCloud.NLU.v1.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.UnitTests/IBM.WatsonDeveloperCloud.NLU.v1.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.UnitTests/IBM.WatsonDeveloperCloud.NLU.v1.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.UnitTests/IBM.WatsonDeveloperCloud.NLU.v1.UnitTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntTests/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntTests/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntTests/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntTests/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests/IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests/IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests/IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests/IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests/IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests/IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests/IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests/IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>


### PR DESCRIPTION
### Summary
This pull request updates .NET Standard version to 2.0. The last [pull request](https://github.com/watson-developer-cloud/dotnet-standard-sdk/pull/336) needed to be reverted since it was merged into `master` rather than the major release branch