### PR TITLE
fixed: VR classify threshold with invariant culture

### DIFF
--- a/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/VisualRecognitionService.cs
+++ b/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/VisualRecognitionService.cs
@@ -138,7 +138,7 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3
 
                 if (threshold != null)
                 {
-                    var thresholdContent = new StringContent(threshold.ToString(), Encoding.UTF8, HttpMediaType.TEXT_PLAIN);
+                    var thresholdContent = new StringContent(threshold.Value.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture), Encoding.UTF8, HttpMediaType.TEXT_PLAIN);
                     formData.Add(thresholdContent, "threshold");
                 }
 

--- a/test/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests/VisualRecognitionServiceIntegrationTests.cs
+++ b/test/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests/VisualRecognitionServiceIntegrationTests.cs
@@ -25,6 +25,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using IBM.WatsonDeveloperCloud.Util;
 using Newtonsoft.Json;
+using System.Globalization;
 
 namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests
 {
@@ -139,6 +140,28 @@ namespace IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests
                 Assert.IsNotNull(result);
                 Assert.IsNotNull(result.Images);
                 Assert.IsTrue(result.Images.Count > 0);
+            }
+        }
+
+        [TestMethod]
+        public void Classify_With_Threshold_Success()
+        {
+            using (FileStream fs = File.OpenRead(localGiraffeFilePath))
+            {
+                var previousCulture = CultureInfo.CurrentCulture;
+
+                CultureInfo.CurrentCulture = new CultureInfo("pt-BR");
+                float value;
+                bool b = float.TryParse("0,1", NumberStyles.Any, new CultureInfo("pt-BR"), out value);
+
+                Console.WriteLine(value);
+                var result = service.Classify(fs, imagesFileContentType: "image/jpeg", threshold: value);
+
+                Assert.IsNotNull(result);
+                Assert.IsNotNull(result.Images);
+                Assert.IsTrue(result.Images.Count > 0);
+
+                CultureInfo.CurrentCulture = previousCulture;
             }
         }
 


### PR DESCRIPTION
### Summary
Fixes https://github.com/watson-developer-cloud/dotnet-standard-sdk/issues/312

This pull request fixes the Visual Recognition Classify method. I was not considering the culture when converting float to string at the threshold.