### PR TITLE
feat(Common): Added a Common package for Watson specific functionality

### DIFF
--- a/IBM.Watson.sln
+++ b/IBM.Watson.sln
@@ -109,6 +109,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IBM.Watson.ToneAnalyzer.v3.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IBM.Watson.VisualRecognition.v3.IntegrationTests", "test\VisualRecognition.v3.IntegrationTests\IBM.Watson.VisualRecognition.v3.IntegrationTests.csproj", "{AF4FA238-32EB-4881-880A-386EA5DA3D05}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{882BFF31-6729-459E-BCEB-556AD4CC31FA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IBM.Watson.Common", "src\IBM.Watson.Common\IBM.Watson.Common.csproj", "{8A4747E7-C4D9-4BBF-A395-893CDD402684}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IBM.Watson.IntegrationTests", "test\IBM.Watson.IntegrationTests\IBM.Watson.IntegrationTests.csproj", "{43BB6A69-61B9-49A9-B9BF-19E2AECBF620}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -279,6 +285,14 @@ Global
 		{AF4FA238-32EB-4881-880A-386EA5DA3D05}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AF4FA238-32EB-4881-880A-386EA5DA3D05}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AF4FA238-32EB-4881-880A-386EA5DA3D05}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A4747E7-C4D9-4BBF-A395-893CDD402684}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A4747E7-C4D9-4BBF-A395-893CDD402684}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A4747E7-C4D9-4BBF-A395-893CDD402684}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A4747E7-C4D9-4BBF-A395-893CDD402684}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43BB6A69-61B9-49A9-B9BF-19E2AECBF620}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43BB6A69-61B9-49A9-B9BF-19E2AECBF620}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43BB6A69-61B9-49A9-B9BF-19E2AECBF620}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43BB6A69-61B9-49A9-B9BF-19E2AECBF620}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -325,6 +339,8 @@ Global
 		{3048FCC3-F233-450C-B12A-7EB33DEA0036} = {C7873F44-7188-49BE-84C5-532BE4E07147}
 		{00C793B6-8364-482F-A13B-723599A87DD0} = {C7873F44-7188-49BE-84C5-532BE4E07147}
 		{AF4FA238-32EB-4881-880A-386EA5DA3D05} = {A1BC3262-1837-40D9-A530-DCFE679927C2}
+		{8A4747E7-C4D9-4BBF-A395-893CDD402684} = {882BFF31-6729-459E-BCEB-556AD4CC31FA}
+		{43BB6A69-61B9-49A9-B9BF-19E2AECBF620} = {882BFF31-6729-459E-BCEB-556AD4CC31FA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B9D9D17B-1C17-402F-B701-DC671528690A}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -190,6 +190,7 @@ test_script:
         dotnet pack .\src\IBM.Watson.TextToSpeech.v1\IBM.Watson.TextToSpeech.v1.csproj --configuration Release
         dotnet pack .\src\IBM.Watson.ToneAnalyzer.v3\IBM.Watson.ToneAnalyzer.v3.csproj --configuration Release
         dotnet pack .\src\IBM.Watson.VisualRecognition.v3\IBM.Watson.VisualRecognition.v3.csproj --configuration Release
+        dotnet pack .\src\IBM.Watson.Common\IBM.Watson.Common.csproj --configuration Release
     }
 
 
@@ -218,6 +219,8 @@ artifacts:
   name: IBM.Watson.NaturalLanguageUnderstanding.v1
 - path: '\src\IBM.Watson.NaturalLanguageClassifier.v1\bin\$(configuration)\*.nupkg'
   name: IBM.Watson.NaturalLanguageClassifier.v1
+- path: '\src\IBM.Watson.Common\bin\$(configuration)\*.nupkg'
+  name: IBM.Watson.Common
 deploy:
 - provider: NuGet
   api_key:

--- a/src/IBM.Watson.Common/Common.cs
+++ b/src/IBM.Watson.Common/Common.cs
@@ -1,0 +1,106 @@
+
+
+
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+/**
+* Copyright 2019 IBM Corp. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+namespace IBM.Watson
+{
+    public partial class Common
+    {
+        /// <summary>
+        /// The SDK version.
+        /// </summary>
+        public const string Version = "watson-apis-dotnet-standard-sdk-2.16.0";
+        private static string os;
+        private static string osVersion;
+        private static string frameworkDescription;
+
+        /// <summary>
+        /// Returns a set of default headers to use with each request.
+        /// </summary>
+        /// <param name="serviceName">The service name to be used in X-IBMCloud-SDK-Analytics header.</param>
+        /// <param name="serviceVersion">The service version to be used in X-IBMCloud-SDK-Analytics header.</param>
+        /// <param name="operation">The operation name to be used in X-IBMCloud-SDK-Analytics header.</param>
+        /// <returns></returns>
+        public static Dictionary<string, string> GetSdkHeaders(string serviceName, string serviceVersion, string operationId)
+        {
+            Dictionary<string, string> sdkHeaders = new Dictionary<string, string>();
+            sdkHeaders.Add("X-IBMCloud-SDK-Analytics", 
+                string.Format("service_name={0};service_version={1};operation_id={2}", 
+                serviceName, 
+                serviceVersion, 
+                operationId));
+
+            if (string.IsNullOrEmpty(os) || string.IsNullOrEmpty(osVersion))
+            {
+                string osInfo = RuntimeInformation.OSDescription;
+                os = GetOs(osInfo);
+                osVersion = GetVersion(osInfo);
+            }
+            if (string.IsNullOrEmpty(frameworkDescription))
+            {
+                frameworkDescription = RuntimeInformation.FrameworkDescription.Trim();
+            }
+
+            sdkHeaders.Add("User-Agent",
+                string.Format(
+                    "{0} {1} {2} {3}",
+                    Version,
+                    CleanupString(os),
+                    CleanupString(osVersion),
+                    CleanupString(frameworkDescription)
+                ));
+            return sdkHeaders;
+        }
+
+        public static string GetVersion(string input)
+        {
+            Regex pattern = new Regex("\\d+(\\.\\d+)+");
+            Match m = pattern.Match(input);
+            return m.Value;
+        }
+
+        public static string GetOs(string input)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return "MacOS";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "Windows";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return "Linux";
+            }
+
+            return input;
+        }
+
+        private static string CleanupString(string input)
+        {
+            Regex pattern = new Regex("[;:#()~/ ]");
+            return pattern.Replace(input, "-");
+        }
+    }
+}

--- a/src/IBM.Watson.Common/IBM.Watson.Common.csproj
+++ b/src/IBM.Watson.Common/IBM.Watson.Common.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>IBM.Watson.Common is a library of functionality needed for SDKs generated using the IBM OpenApi SDK generator. The library has functionality specific for the generated SDK.</Description>
+        <AssemblyTitle>IBM.Watson.Common</AssemblyTitle>
+        <VersionPrefix>2.16.0</VersionPrefix>
+        <Authors>IBM Watson</Authors>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <AssemblyName>IBM.Watson.Common</AssemblyName>
+        <PackageId>IBM.Watson.Common</PackageId>
+        <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>
+        <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
+        <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
+        <Version>2.16.0</Version>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+        <DebugType>full</DebugType>
+        <DebugSymbols>true</DebugSymbols>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        <DebugType>full</DebugType>
+        <DebugSymbols>true</DebugSymbols>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    </ItemGroup>
+
+</Project>

--- a/test/IBM.Watson.IntegrationTests/CommonIntegrationTests.cs
+++ b/test/IBM.Watson.IntegrationTests/CommonIntegrationTests.cs
@@ -1,0 +1,68 @@
+﻿/**
+* Copyright 2019 IBM Corp. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace IBM.Watson.IntegrationTests
+{
+    [TestClass]
+    public class CommonIntegrationTests
+    {
+        [TestMethod]
+        public void TestGetDefaultHeaders()
+        {
+            Dictionary<string, string> sdkHeaders = Common.GetSdkHeaders("bogusServiceName", "bogusServiceVersion", "bogusOperationid");
+            Assert.IsTrue(sdkHeaders.Count == 2);
+            Assert.IsTrue(sdkHeaders.ContainsKey("X-IBMCloud-SDK-Analytics"));
+            Assert.IsTrue(sdkHeaders.ContainsKey("User-Agent"));
+            Assert.IsTrue(sdkHeaders["X-IBMCloud-SDK-Analytics"] == "service_name=bogusServiceName;service_version=bogusServiceVersion;operation_id=bogusOperationid");
+            Assert.IsTrue(sdkHeaders["User-Agent"].Contains(Common.Version));
+            Assert.IsFalse(sdkHeaders["User-Agent"].Contains("("));
+            Assert.IsFalse(sdkHeaders["User-Agent"].Contains(")"));
+            Assert.IsFalse(sdkHeaders["User-Agent"].Contains(":"));
+            Assert.IsFalse(sdkHeaders["User-Agent"].Contains(";"));
+            Assert.IsFalse(sdkHeaders["User-Agent"].Contains("#"));
+            Assert.IsFalse(sdkHeaders["User-Agent"].Contains("~"));
+            Assert.IsTrue(sdkHeaders["User-Agent"].Split(" ").Length == 4);
+        }
+
+        [TestMethod]
+        public void GetVersionWindows()
+        {
+            string osDescription = "Microsoft Windows 10.0.17134 ";
+            string osVersion = Common.GetVersion(osDescription);
+            Assert.IsTrue(osVersion == "10.0.17134");
+        }
+
+        [TestMethod]
+        public void GetVersionOSX()
+        {
+            string osDescription = "Darwin 17.7.0 Darwin Kernel Version 17.7.0: Fri Nov  2 20:43:16 PDT 2018; root:xnu-4570.71.17~1/RELEASE_X86_64";
+            string osVersion = Common.GetVersion(osDescription);
+            Assert.IsTrue(osVersion == "17.7.0");
+        }
+
+        [TestMethod]
+        public void GetVersionLinux()
+        {
+            string osDescription = "4.19.28-1-MANJARO#1SMPPREEMPTSunMar1008:32:42UTC2019";
+            string osVersion = Common.GetVersion(osDescription);
+            Assert.IsTrue(osVersion == "4.19.28");
+        }
+    }
+}

--- a/test/IBM.Watson.IntegrationTests/CoreIntegrationTests.cs
+++ b/test/IBM.Watson.IntegrationTests/CoreIntegrationTests.cs
@@ -29,10 +29,10 @@ using IBM.Watson.VisualRecognition.v3;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-namespace IBM.Watson.Core.IntegrationTests
+namespace IBM.Watson.IntegrationTests
 {
     [TestClass]
-    public class CoreIntegrationTests
+    public class ExternalCredentialsIntegrationTests
     {
         [TestMethod]
         public void GetCredentialsPaths_Success()

--- a/test/IBM.Watson.IntegrationTests/IBM.Watson.IntegrationTests.csproj
+++ b/test/IBM.Watson.IntegrationTests/IBM.Watson.IntegrationTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <VersionPrefix>2.16.0</VersionPrefix>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <AssemblyName>IBM.Watson.Core.IntegrationTests</AssemblyName>
+    <AssemblyName>IBM.Watson.IntegrationTests</AssemblyName>
     <PackageId>IBM.Watson.Core.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -44,6 +44,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\IBM.Watson.Assistant.v1\IBM.Watson.Assistant.v1.csproj" />
     <ProjectReference Include="..\..\src\IBM.Watson.Assistant.v2\IBM.Watson.Assistant.v2.csproj" />
+    <ProjectReference Include="..\..\src\IBM.Watson.Common\IBM.Watson.Common.csproj" />
     <ProjectReference Include="..\..\src\IBM.Watson.CompareComply.v1\IBM.Watson.CompareComply.v1.csproj" />
     <ProjectReference Include="..\..\src\IBM.Watson.Discovery.v1\IBM.Watson.Discovery.v1.csproj" />
     <ProjectReference Include="..\..\src\IBM.Watson.LanguageTranslator.v3\IBM.Watson.LanguageTranslator.v3.csproj" />


### PR DESCRIPTION
### Summary
This pull request adds a common class for the Watson .NET SDK. This contains mostly functionality to get headers for rest requests. This PR does not include implementing this in the service abstractions - Phil has already added this to the generator. Additionally issues https://github.com/watson-developer-cloud/dotnet-standard-sdk/issues/335 and https://github.com/watson-developer-cloud/dotnet-standard-sdk/issues/342 point out that certain characters are causing issues in getting analytics headers. We remove the characters in `CleanupString`. 

One thing to note is that the OS info isn't consistent across platforms. For example
Windows: 
`Microsoft Windows 10.0.17134 `
OSX
`Darwin 17.7.0 Darwin Kernel Version 17.7.0: Fri Nov  2 20:43:16 PDT 2018; root:xnu-4570.71.17~1/RELEASE_X86_64`
Linux (Manjaro)
`4.19.28-1-MANJARO#1SMPPREEMPTSunMar1008:32:42UTC2019`

Instead of parsing this (since I don't know what other linux platforms will return) I look for 
```
RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
```
and return `MacOS`

Versions are correctly parsed from runtime info.