### PR TITLE
Parse user agent

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 commit = True
-current_version = 3.0.0
+current_version = 2.17.0
 message = docs: Update version numbers from {current_version} -> {new_version}
 
 [bumpversion:file:Doxyfile]

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Watson Developer Cloud .NET Standard SDK"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.0.0
+PROJECT_NUMBER         = 2.17.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -171,7 +171,7 @@ test_script:
 
     {
         Write-Output "branchName is master and not a pull request - running semantic release"
-        npx semantic-release@15.11.0
+        # npx semantic-release@15.11.0
     }
 
     ElseIf($branchName -eq $env:APPVEYOR_REPO_TAG_NAME)

--- a/examples/IBM.WatsonDeveloperCloud.Assistant.v2.Example/IBM.WatsonDeveloperCloud.Assistant.v2.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.Assistant.v2.Example/IBM.WatsonDeveloperCloud.Assistant.v2.Example.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1.Example</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -9,7 +9,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/examples/IBM.WatsonDeveloperCloud.Conversation.v1.Example/IBM.WatsonDeveloperCloud.Conversation.v1.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.Conversation.v1.Example/IBM.WatsonDeveloperCloud.Conversation.v1.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1.Example</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/examples/IBM.WatsonDeveloperCloud.Discovery.v1.Example/IBM.WatsonDeveloperCloud.Discovery.v1.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.Discovery.v1.Example/IBM.WatsonDeveloperCloud.Discovery.v1.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Discovery.v1.Example</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/examples/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.Example</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/examples/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.Ex/IBM.WatsonDeveloperCloud.NLU.v1.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.Ex/IBM.WatsonDeveloperCloud.NLU.v1.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.Ex</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/examples/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.Example</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/examples/IBM.WatsonDeveloperCloud.SpeechToText.v1.Example/IBM.WatsonDeveloperCloud.SpeechToText.v1.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.SpeechToText.v1.Example/IBM.WatsonDeveloperCloud.SpeechToText.v1.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.SpeechToText.v1.Example</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/examples/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example.csproj
+++ b/examples/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.Example</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.Assistant.v1/IBM.WatsonDeveloperCloud.Assistant.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.Assistant.v1/IBM.WatsonDeveloperCloud.Assistant.v1.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.Assistant.v1 wraps the Watson Developer Cloud Assistant service (http://www.ibm.com/watson/developercloud/assistant.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.Assistant.v1</AssemblyTitle>
-        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionPrefix>2.17.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.Assistant.v1</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>3.0.0</Version>
+        <Version>2.17.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.Assistant.v1/README.md
+++ b/src/IBM.WatsonDeveloperCloud.Assistant.v1/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v3.0.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.Assistant.v1/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.17.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.Assistant.v1/)
 
 ### Assistant
 
@@ -15,7 +15,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.Assistant.v1
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.Assistant.v1" Version="3.0.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.Assistant.v1" Version="2.17.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.Assistant.v2/IBM.WatsonDeveloperCloud.Assistant.v2.csproj
+++ b/src/IBM.WatsonDeveloperCloud.Assistant.v2/IBM.WatsonDeveloperCloud.Assistant.v2.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.Assistant.v2 wraps the Watson Developer Cloud Assistant service (http://www.ibm.com/watson/developercloud/assistant.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.Assistant.v2</AssemblyTitle>
-        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionPrefix>2.17.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.Assistant.v2</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>3.0.0</Version>
+        <Version>2.17.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.Assistant.v2/README.md
+++ b/src/IBM.WatsonDeveloperCloud.Assistant.v2/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v3.0.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.Assistant.v2/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.17.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.Assistant.v2/)
 
 ### Assistant
 
@@ -15,7 +15,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.Assistant.v2
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.Assistant.v2" Version="3.0.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.Assistant.v2" Version="2.17.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.CompareComply.v1/IBM.WatsonDeveloperCloud.CompareComply.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.CompareComply.v1/IBM.WatsonDeveloperCloud.CompareComply.v1.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.CompareComply.v1 wraps the Watson Developer Cloud Compare Comply service (http://www.ibm.com/watson/developercloud/compare-comply.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.CompareComply.v1</AssemblyTitle>
-        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionPrefix>2.17.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.CompareComply.v1</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>3.0.0</Version>
+        <Version>2.17.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.CompareComply.v1/README.md
+++ b/src/IBM.WatsonDeveloperCloud.CompareComply.v1/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v3.0.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.CompareComply.v1/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.17.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.CompareComply.v1/)
 
 ### Compare Comply
 IBM Watson™ [Compare and Comply]() analyzes governing documents to provide details about critical aspects of the documents.
@@ -14,7 +14,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.ComnpareComply.v1
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.CompareComply.v1" Version="3.0.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.CompareComply.v1" Version="2.17.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.Conversation.v1/IBM.WatsonDeveloperCloud.Conversation.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.Conversation.v1/IBM.WatsonDeveloperCloud.Conversation.v1.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.Conversation.v1 wraps the Watson Developer Cloud Conversation service (http://www.ibm.com/watson/developercloud/conversation.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.Conversation.v1</AssemblyTitle>
-        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionPrefix>2.17.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>3.0.0</Version>
+        <Version>2.17.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.Conversation.v1/README.md
+++ b/src/IBM.WatsonDeveloperCloud.Conversation.v1/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v3.0.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.Conversation.v1/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.17.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.Conversation.v1/)
 
 ### Conversation
 **Conversation V1 is deprecated and will be removed in the next major release of the SDK. Use Assistant V1 or Assistant V2.**
@@ -15,7 +15,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.Conversation.v1
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.Conversation.v1" Version="3.0.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.Conversation.v1" Version="2.17.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.Discovery.v1/IBM.WatsonDeveloperCloud.Discovery.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.Discovery.v1/IBM.WatsonDeveloperCloud.Discovery.v1.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.Discovery.v1 wraps the Watson Developer Cloud Discovery service (http://www.ibm.com/watson/developercloud/discovery.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.Discovery.v1</AssemblyTitle>
-        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionPrefix>2.17.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.Discovery.v1</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>3.0.0</Version>
+        <Version>2.17.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.Discovery.v1/README.md
+++ b/src/IBM.WatsonDeveloperCloud.Discovery.v1/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v3.0.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.Discovery.v1/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.17.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.Discovery.v1/)
 
 ### Discovery
 The IBM Watson™ [Discovery][discovery] service makes it possible to rapidly build cognitive, cloud-based exploration applications that unlock actionable insights hidden in unstructured data - including your own proprietary data, as well as public and third-party data.
@@ -14,7 +14,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.Discovery.v1
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.Discovery.v1" Version="3.0.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.Discovery.v1" Version="2.17.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.csproj
+++ b/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.LanguageTranslator.v3 wraps the Watson Developer Cloud Language Translator service (http://www.ibm.com/watson/developercloud/language-translator.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.LanguageTranslator.v3</AssemblyTitle>
-        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionPrefix>2.17.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v3</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>3.0.0</Version>
+        <Version>2.17.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/README.md
+++ b/src/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v3.0.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.17.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.LanguageTranslator.v3/)
 
 ### Language Translator V3
 
@@ -15,7 +15,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.LanguageTranslator.v3
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.LanguageTranslator.v3" Version="3.0.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.LanguageTranslator.v3" Version="2.17.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1 wraps the Watson Developer Cloud Natural Language Classifier service (http://www.ibm.com/watson/developercloud/natural-language-classifier.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1</AssemblyTitle>
-        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionPrefix>2.17.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>3.0.0</Version>
+        <Version>2.17.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1/README.md
+++ b/src/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v3.0.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.17.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1/)
 
 ### Natural Language Classifier
 IBM Watson™ [Natural Language Classifier][natural_language_classifier] uses machine learning algorithms to return the top matching predefined classes for short text input. You create and train a classifier to connect predefined classes to example texts so that the service can apply those classes to new inputs.
@@ -14,7 +14,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.NaturalLanguageClassifier.v1
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.NaturalLangaugeClassifier.v1" Version="3.0.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.NaturalLangaugeClassifier.v1" Version="2.17.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1 wraps the Watson Developer Cloud Natural Language Understanding service (http://www.ibm.com/watson/developercloud/natural-language-understanding.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1</AssemblyTitle>
-        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionPrefix>2.17.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>3.0.0</Version>
+        <Version>2.17.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1/README.md
+++ b/src/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v3.0.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.17.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1/)
 
 ### Natural Language Understanding
 With [Natural Language Understanding][natural_language_understanding] developers can analyze semantic features of text input, including - categories, concepts, emotion, entities, keywords, metadata, relations, semantic roles, and sentiment.
@@ -14,7 +14,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1" Version="3.0.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1" Version="2.17.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.PersonalityInsights.v3/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.csproj
+++ b/src/IBM.WatsonDeveloperCloud.PersonalityInsights.v3/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.PersonalityInsights.v3 wraps the Watson Developer Cloud Personality Insights service (http://www.ibm.com/watson/developercloud/personality-insights.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.PersonalityInsights.v3</AssemblyTitle>
-        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionPrefix>2.17.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.PersonalityInsights.v3</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>3.0.0</Version>
+        <Version>2.17.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.PersonalityInsights.v3/README.md
+++ b/src/IBM.WatsonDeveloperCloud.PersonalityInsights.v3/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v3.0.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.PersonalityInsights.v3/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.17.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.PersonalityInsights.v3/)
 
 ### Personality Insights
 
@@ -19,7 +19,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.PersonalityInsights.v3
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.PersonalityInsights.v3" Version="3.0.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.PersonalityInsights.v3" Version="2.17.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/IBM.WatsonDeveloperCloud.SpeechToText.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/IBM.WatsonDeveloperCloud.SpeechToText.v1.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.SpeechToText.v1 wraps the Watson Developer Cloud Speech To Text service (http://www.ibm.com/watson/developercloud/speech-to-text.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.SpeechToText.v1</AssemblyTitle>
-        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionPrefix>2.17.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.SpeechToText.v1</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>3.0.0</Version>
+        <Version>2.17.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/README.md
+++ b/src/IBM.WatsonDeveloperCloud.SpeechToText.v1/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v3.0.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.SpeechToText.v1/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.17.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.SpeechToText.v1/)
 
 ### Speech to Text
 
@@ -15,7 +15,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.SpeechToText.v1
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.SpeechToText.v1" Version="3.0.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.SpeechToText.v1" Version="2.17.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.TextToSpeech.v1/IBM.WatsonDeveloperCloud.TextToSpeech.v1.csproj
+++ b/src/IBM.WatsonDeveloperCloud.TextToSpeech.v1/IBM.WatsonDeveloperCloud.TextToSpeech.v1.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.TextToSpeech.v1 wraps the Watson Developer Cloud Text To Speech service (http://www.ibm.com/watson/developercloud/text-to-speech.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.TextToSpeech.v1</AssemblyTitle>
-        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionPrefix>2.17.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.TextToSpeech.v1</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>3.0.0</Version>
+        <Version>2.17.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.csproj
+++ b/src/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3 wraps the Watson Developer Cloud Tone Analyzer service (http://www.ibm.com/watson/developercloud/tone-analyzer.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3</AssemblyTitle>
-        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionPrefix>2.17.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>3.0.0</Version>
+        <Version>2.17.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3/README.md
+++ b/src/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v3.0.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.17.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3/)
 
 ### Tone Analyzer
 
@@ -15,7 +15,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.ToneAnalyzer.v3
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.ToneAnalyzer.v3" Version="3.0.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.ToneAnalyzer.v3" Version="2.17.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/IBM.WatsonDeveloperCloud.VisualRecognition.v3.csproj
+++ b/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/IBM.WatsonDeveloperCloud.VisualRecognition.v3.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>IBM.WatsonDeveloperCloud.VisualRecognition.v3 wraps the Watson Developer Cloud Visual Recognition service (http://www.ibm.com/watson/developercloud/visual-recognition.html)</Description>
         <AssemblyTitle>IBM.WatsonDeveloperCloud.VisualRecognition.v3</AssemblyTitle>
-        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionPrefix>2.17.0</VersionPrefix>
         <Authors>Watson Developer Cloud</Authors>
         <TargetFramework>netstandard1.3</TargetFramework>
         <AssemblyName>IBM.WatsonDeveloperCloud.VisualRecognition.v3</AssemblyName>
@@ -12,7 +12,7 @@
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
         <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-        <Version>3.0.0</Version>
+        <Version>2.17.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/README.md
+++ b/src/IBM.WatsonDeveloperCloud.VisualRecognition.v3/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v3.0.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.VisualRecognition.v3/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.17.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud.VisualRecognition.v3/)
 
 ### Visual Recognition
 The IBM Watson™ [Visual Recognition][visual-recognition] service uses deep learning algorithms to identify scenes, objects, and celebrity faces in images you upload to the service. You can create and train a custom classifier to identify subjects that suit your needs.
@@ -14,7 +14,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud.VisualRecognition.v3
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud.VisualRecognition.v3" Version="3.0.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud.VisualRecognition.v3" Version="2.17.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud/Constants.cs
+++ b/src/IBM.WatsonDeveloperCloud/Constants.cs
@@ -26,7 +26,7 @@ namespace IBM.WatsonDeveloperCloud
         /// The version number for this SDK build. Added to the header in 
         /// each request as `User-Agent`.
         /// </summary>
-        public static readonly string SDK_VERSION = "watson-apis-dotnet-sdk-3.0.0";
+        public static readonly string SDK_VERSION = "watson-apis-dotnet-sdk-2.17.0";
         /// <summary>
         /// A constant used to access custom request headers in the dynamic
         /// customData object.

--- a/src/IBM.WatsonDeveloperCloud/Http/HttpFactory.cs
+++ b/src/IBM.WatsonDeveloperCloud/Http/HttpFactory.cs
@@ -20,11 +20,17 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Formatting;
 using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
+using IBM.WatsonDeveloperCloud.Util;
 
 namespace IBM.WatsonDeveloperCloud.Http
 {
     internal static class HttpFactory
     {
+        private static string os;
+        private static string osVersion;
+        private static string frameworkDescription;
+
         public static MediaTypeFormatter GetFormatter(MediaTypeFormatterCollection formatters, MediaTypeHeaderValue contentType = null)
         {
             if (!formatters.Any())
@@ -45,17 +51,24 @@ namespace IBM.WatsonDeveloperCloud.Http
 
             // add default headers
             request.Headers.Add("accept", formatters.SelectMany(p => p.SupportedMediaTypes).Select(p => p.MediaType));
-            string osInfo = System.Runtime.InteropServices.RuntimeInformation.OSDescription;
-            int versionIndex = osInfo.IndexOfAny("0123456789".ToCharArray());
-            string os = osInfo.Substring(0, versionIndex).Replace(" ", "");
-            string osVersion = osInfo.Substring(versionIndex).Replace(" ", "");
-            request.Headers.Add("User-Agent", 
-                string.Format(
-                    "{0} {1} {2} {3}", 
-                    Constants.SDK_VERSION, 
-                    os,
-                    osVersion,
-                    System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.Replace(" ", "")
+            if (string.IsNullOrEmpty(os) || string.IsNullOrEmpty(osVersion))
+            {
+                string osInfo = RuntimeInformation.OSDescription;
+                os = Utility.GetOs(osInfo);
+                osVersion = Utility.GetVersion(osInfo);
+            }
+            if (string.IsNullOrEmpty(frameworkDescription))
+            {
+                frameworkDescription = RuntimeInformation.FrameworkDescription.Trim();
+            }
+
+            request.Headers.Add("User-Agent",
+                 string.Format(
+                     "{0} {1} {2} {3}",
+                    Constants.SDK_VERSION,
+                    Utility.CleanupUserAgentString(os),
+                    Utility.CleanupUserAgentString(osVersion),
+                    Utility.CleanupUserAgentString(frameworkDescription)
                 ));
 
             return request;

--- a/src/IBM.WatsonDeveloperCloud/IBM.WatsonDeveloperCloud.csproj
+++ b/src/IBM.WatsonDeveloperCloud/IBM.WatsonDeveloperCloud.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>The IBM.WatsonDeveloperCloud is a core project of Watson SDK in .Net. The other Watson SDK in .Net service packages depend on this package.</Description>
     <AssemblyTitle>IBM.WatsonDeveloperCloud</AssemblyTitle>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <Authors>Watson Developer Cloud</Authors>
     <TargetFramework>netstandard1.3</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud</AssemblyName>
@@ -15,7 +15,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/IBM.WatsonDeveloperCloud/README.md
+++ b/src/IBM.WatsonDeveloperCloud/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/badge/nuget-v3.0.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud/)
+[![NuGet](https://img.shields.io/badge/nuget-v2.17.0-green.svg?style=flat)](https://www.nuget.org/packages/IBM.WatsonDeveloperCloud/)
 
 ### Watson Developer Cloud
 
@@ -15,7 +15,7 @@ PM > Install-Package IBM.WatsonDeveloperCloud
 ```xml
 
 <ItemGroup>
-    <PackageReference Include="IBM.WatsonDeveloperCloud" Version="3.0.0" />
+    <PackageReference Include="IBM.WatsonDeveloperCloud" Version="2.17.0" />
 </ItemGroup>
 
 ```

--- a/src/IBM.WatsonDeveloperCloud/Util/Utility.cs
+++ b/src/IBM.WatsonDeveloperCloud/Util/Utility.cs
@@ -20,6 +20,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace IBM.WatsonDeveloperCloud.Util
@@ -167,6 +169,37 @@ namespace IBM.WatsonDeveloperCloud.Util
             }
 
             return filePathsToLoad;
+        }
+
+        public static string GetVersion(string input)
+        {
+            Regex pattern = new Regex("\\d+(\\.\\d+)+");
+            Match m = pattern.Match(input);
+            return m.Value;
+        }
+
+        public static string GetOs(string input)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return "MacOS";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "Windows";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return "Linux";
+            }
+
+            return input;
+        }
+
+        public static string CleanupUserAgentString(string input)
+        {
+            Regex pattern = new Regex("[;:#()~/ ]");
+            return pattern.Replace(input, "-");
         }
     }
 }

--- a/test/IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Assistant.v1.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests/IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests/IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Assistant.v1.UnitTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.Assistant.v2.IntTests/IBM.WatsonDeveloperCloud.Assistant.v2.IntTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Assistant.v2.IntTests/IBM.WatsonDeveloperCloud.Assistant.v2.IntTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Assistant.v2.IntTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Assistant.v2.IntTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests/IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests/IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Assistant.v2.UnitTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.CompareComply.v1.IT/IBM.WatsonDeveloperCloud.CompareComply.v1.IT.csproj
+++ b/test/IBM.WatsonDeveloperCloud.CompareComply.v1.IT/IBM.WatsonDeveloperCloud.CompareComply.v1.IT.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.CompareComply.v1.IT</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.CompareComply.v1.IT</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.CompareComply.v1.UT/IBM.WatsonDeveloperCloud.CompareComply.v1.UT.csproj
+++ b/test/IBM.WatsonDeveloperCloud.CompareComply.v1.UT/IBM.WatsonDeveloperCloud.CompareComply.v1.UT.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.CompareComply.v1.UT</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.CompareComply.v1.UT</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Conversation.v1.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests/IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests/IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Conversation.v1.UnitTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.Core.IntegrationTests/IBM.WatsonDeveloperCloud.Core.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Core.IntegrationTests/IBM.WatsonDeveloperCloud.Core.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Core.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Core.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.Core.IntegrationTests/UserAgentParsingTests.cs
+++ b/test/IBM.WatsonDeveloperCloud.Core.IntegrationTests/UserAgentParsingTests.cs
@@ -1,0 +1,80 @@
+﻿/**
+* Copyright 2019 IBM Corp. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+using IBM.WatsonDeveloperCloud.Util;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace IBM.WatsonDeveloperCloud.Core.IntegrationTests
+{
+    [TestClass]
+    public class UserAgentParsingTests
+    {
+        [TestMethod]
+        public void TestGetDefaultHeaders()
+        {
+            Dictionary<string, string> sdkHeaders = new Dictionary<string, string>();
+            string osInfo = RuntimeInformation.OSDescription;
+            string os = Utility.GetOs(osInfo);
+            string osVersion = Utility.GetVersion(osInfo);
+            string frameworkDescription = RuntimeInformation.FrameworkDescription.Trim();
+
+            sdkHeaders.Add("User-Agent", string.Format(
+                    "{0} {1} {2} {3}",
+                    Constants.SDK_VERSION,
+                    Utility.CleanupUserAgentString(os),
+                    Utility.CleanupUserAgentString(osVersion),
+                    Utility.CleanupUserAgentString(frameworkDescription)
+                ));
+            Assert.IsTrue(sdkHeaders.Count == 1);
+            Assert.IsTrue(sdkHeaders.ContainsKey("User-Agent"));
+            Assert.IsTrue(sdkHeaders["User-Agent"].Contains(Constants.SDK_VERSION));
+            Assert.IsFalse(sdkHeaders["User-Agent"].Contains("("));
+            Assert.IsFalse(sdkHeaders["User-Agent"].Contains(")"));
+            Assert.IsFalse(sdkHeaders["User-Agent"].Contains(":"));
+            Assert.IsFalse(sdkHeaders["User-Agent"].Contains(";"));
+            Assert.IsFalse(sdkHeaders["User-Agent"].Contains("#"));
+            Assert.IsFalse(sdkHeaders["User-Agent"].Contains("~"));
+            Assert.IsTrue(sdkHeaders["User-Agent"].Split().Length == 4);
+        }
+
+        [TestMethod]
+        public void GetVersionWindows()
+        {
+            string osDescription = "Microsoft Windows 10.0.17134 ";
+            string osVersion = Utility.GetVersion(osDescription);
+            Assert.IsTrue(osVersion == "10.0.17134");
+        }
+
+        [TestMethod]
+        public void GetVersionOSX()
+        {
+            string osDescription = "Darwin 17.7.0 Darwin Kernel Version 17.7.0: Fri Nov  2 20:43:16 PDT 2018; root:xnu-4570.71.17~1/RELEASE_X86_64";
+            string osVersion = Utility.GetVersion(osDescription);
+            Assert.IsTrue(osVersion == "17.7.0");
+        }
+
+        [TestMethod]
+        public void GetVersionLinux()
+        {
+            string osDescription = "Linux 4.19.28-1-MANJARO #1 SMP PREEMPT Sun Mar 10 08:32:42 UTC 2019";
+            string osVersion = Utility.GetVersion(osDescription);
+            Assert.IsTrue(osVersion == "4.19.28");
+        }
+    }
+}

--- a/test/IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests/IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Discovery.v1.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests/IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.Discovery.v1.UnitTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests/IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.LanguageTranslator.v3.UnitTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests/IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests/IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.NLC.v1.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.IntTests/IBM.WatsonDeveloperCloud.NLU.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.IntTests/IBM.WatsonDeveloperCloud.NLU.v1.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.IntTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.IntTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.UnitTests/IBM.WatsonDeveloperCloud.NLU.v1.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.UnitTests/IBM.WatsonDeveloperCloud.NLU.v1.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.NaturalLanguageUnderstanding.v1.UnitTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntTests/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntTests/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests/IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.PersonalityInsights.v3.UnitTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests/IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests/IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.SpeechToText.v1.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests/IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests/IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.TextToSpeech.v1.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests/IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.ToneAnalyzer.v3.UnitTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests.csproj
+++ b/test/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests/IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests</AssemblyName>
     <PackageId>IBM.WatsonDeveloperCloud.VisualRecognition.v3.IntegrationTests</PackageId>
@@ -11,7 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>2.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
### Summary
https://github.com/watson-developer-cloud/dotnet-standard-sdk/pull/344 inadvertently released .NET SDK v3.0.0. This was due to a breaking change that was inadvertently [merged](https://github.com/watson-developer-cloud/dotnet-standard-sdk/pull/336) and [reverted](https://github.com/watson-developer-cloud/dotnet-standard-sdk/pull/338) but the `BREAKING CHANGE` annotation was still in the git history. 

In this pull request we have the same changes as https://github.com/watson-developer-cloud/dotnet-standard-sdk/pull/344 but I've manually bumped version and disabled semantic release temporarily. Once merged into master semantic release will be skipped but the deploy process to Nuget will happen as planned. I will then manually draft and put out a release. 

I plan to create a branch of `v2.x.x` from before when #336 was merged and cherry pick `0f4678d` for any updates to the older version.  