### PR TITLE
Parse user agent

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,5 @@
 {
-  "branch": "master",
+  "branch": "v2.x.x",
   "verifyConditions": [],
   "prepare": [
     "@semantic-release/git",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,7 +77,7 @@ after_build:
     if($env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null)
     {
       
-      If($branchName -eq "development" -or $branchName -eq $env:APPVEYOR_REPO_TAG_NAME -or $branchName -eq "master")
+      If($branchName -eq "development" -or $branchName -eq $env:APPVEYOR_REPO_TAG_NAME -or $branchName -eq "v2.x.x")
 
       {
           .\packages\Doxygen.1.8.14\tools\doxygen.exe Doxyfile
@@ -167,10 +167,10 @@ test_script:
         }
     }
 
-    If($branchName -eq "master" -and $env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null)
+    If($branchName -eq "v2.x.x" -and $env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null)
 
     {
-        Write-Output "branchName is master and not a pull request - running semantic release"
+        Write-Output "branchName is v2.x.x and not a pull request - running semantic release"
         npx semantic-release@15.11.0
     }
 
@@ -226,6 +226,6 @@ deploy:
   api_key:
     secure: q7ya4MDWM5JDI2JYw1DxSKTgX+jwbvdlRKPjVg1Cijxb33r1K5qSAabnsUHcWTLf
   on:
-    branch: master
+    branch: v2.x.x
     APPVEYOR_REPO_TAG: true
     

--- a/src/IBM.WatsonDeveloperCloud/Http/HttpFactory.cs
+++ b/src/IBM.WatsonDeveloperCloud/Http/HttpFactory.cs
@@ -15,16 +15,22 @@
 *
 */
 
+using IBM.WatsonDeveloperCloud.Util;
 using System;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Formatting;
 using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
 
 namespace IBM.WatsonDeveloperCloud.Http
 {
     internal static class HttpFactory
     {
+        private static string os;
+        private static string osVersion;
+        private static string frameworkDescription;
+
         public static MediaTypeFormatter GetFormatter(MediaTypeFormatterCollection formatters, MediaTypeHeaderValue contentType = null)
         {
             if (!formatters.Any())
@@ -45,17 +51,25 @@ namespace IBM.WatsonDeveloperCloud.Http
 
             // add default headers
             request.Headers.Add("accept", formatters.SelectMany(p => p.SupportedMediaTypes).Select(p => p.MediaType));
-            string osInfo = System.Runtime.InteropServices.RuntimeInformation.OSDescription;
-            int versionIndex = osInfo.IndexOfAny("0123456789".ToCharArray());
-            string os = osInfo.Substring(0, versionIndex).Replace(" ", "");
-            string osVersion = osInfo.Substring(versionIndex).Replace(" ", "");
-            request.Headers.Add("User-Agent", 
+
+            if (string.IsNullOrEmpty(os) || string.IsNullOrEmpty(osVersion))
+            {
+                string osInfo = RuntimeInformation.OSDescription;
+                os = Utility.GetOs(osInfo);
+                osVersion = Utility.GetVersion(osInfo);
+            }
+            if (string.IsNullOrEmpty(frameworkDescription))
+            {
+                frameworkDescription = RuntimeInformation.FrameworkDescription.Trim();
+            }
+
+            request.Headers.Add("User-Agent",
                 string.Format(
-                    "{0} {1} {2} {3}", 
-                    Constants.SDK_VERSION, 
-                    os,
-                    osVersion,
-                    System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.Replace(" ", "")
+                    "{0} {1} {2} {3}",
+                    Constants.SDK_VERSION,
+                    Utility.CleanupUserAgentString(os),
+                    Utility.CleanupUserAgentString(osVersion),
+                    Utility.CleanupUserAgentString(frameworkDescription)
                 ));
 
             return request;

--- a/src/IBM.WatsonDeveloperCloud/Util/Utility.cs
+++ b/src/IBM.WatsonDeveloperCloud/Util/Utility.cs
@@ -20,6 +20,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace IBM.WatsonDeveloperCloud.Util
@@ -167,6 +169,37 @@ namespace IBM.WatsonDeveloperCloud.Util
             }
 
             return filePathsToLoad;
+        }
+
+        public static string GetVersion(string input)
+        {
+            Regex pattern = new Regex("\\d+(\\.\\d+)+");
+            Match m = pattern.Match(input);
+            return m.Value;
+        }
+
+        public static string GetOs(string input)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return "MacOS";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "Windows";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return "Linux";
+            }
+
+            return input;
+        }
+
+        public static string CleanupUserAgentString(string input)
+        {
+            Regex pattern = new Regex("[;:#()~/ ]");
+            return pattern.Replace(input, "-");
         }
     }
 }

--- a/test/IBM.WatsonDeveloperCloud.Core.IntegrationTests/UserAgentParsingTests.cs
+++ b/test/IBM.WatsonDeveloperCloud.Core.IntegrationTests/UserAgentParsingTests.cs
@@ -1,0 +1,80 @@
+﻿/**
+* Copyright 2019 IBM Corp. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+using IBM.WatsonDeveloperCloud.Util;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace IBM.WatsonDeveloperCloud.Core.IntegrationTests
+{
+    [TestClass]
+    public class UserAgentParsingTests
+    {
+        [TestMethod]
+        public void TestGetDefaultHeaders()
+        {
+            Dictionary<string, string> sdkHeaders = new Dictionary<string, string>();
+            string osInfo = RuntimeInformation.OSDescription;
+            string os = Utility.GetOs(osInfo);
+            string osVersion = Utility.GetVersion(osInfo);
+            string frameworkDescription = RuntimeInformation.FrameworkDescription.Trim();
+
+            sdkHeaders.Add("User-Agent", string.Format(
+                    "{0} {1} {2} {3}",
+                    Constants.SDK_VERSION,
+                    Utility.CleanupUserAgentString(os),
+                    Utility.CleanupUserAgentString(osVersion),
+                    Utility.CleanupUserAgentString(frameworkDescription)
+                ));
+            Assert.IsTrue(sdkHeaders.Count == 1);
+            Assert.IsTrue(sdkHeaders.ContainsKey("User-Agent"));
+            Assert.IsTrue(sdkHeaders["User-Agent"].Contains(Constants.SDK_VERSION));
+            Assert.IsFalse(sdkHeaders["User-Agent"].Contains("("));
+            Assert.IsFalse(sdkHeaders["User-Agent"].Contains(")"));
+            Assert.IsFalse(sdkHeaders["User-Agent"].Contains(":"));
+            Assert.IsFalse(sdkHeaders["User-Agent"].Contains(";"));
+            Assert.IsFalse(sdkHeaders["User-Agent"].Contains("#"));
+            Assert.IsFalse(sdkHeaders["User-Agent"].Contains("~"));
+            Assert.IsTrue(sdkHeaders["User-Agent"].Split().Length == 4);
+        }
+
+        [TestMethod]
+        public void GetVersionWindows()
+        {
+            string osDescription = "Microsoft Windows 10.0.17134 ";
+            string osVersion = Utility.GetVersion(osDescription);
+            Assert.IsTrue(osVersion == "10.0.17134");
+        }
+
+        [TestMethod]
+        public void GetVersionOSX()
+        {
+            string osDescription = "Darwin 17.7.0 Darwin Kernel Version 17.7.0: Fri Nov  2 20:43:16 PDT 2018; root:xnu-4570.71.17~1/RELEASE_X86_64";
+            string osVersion = Utility.GetVersion(osDescription);
+            Assert.IsTrue(osVersion == "17.7.0");
+        }
+
+        [TestMethod]
+        public void GetVersionLinux()
+        {
+            string osDescription = "Linux 4.19.28-1-MANJARO #1 SMP PREEMPT Sun Mar 10 08:32:42 UTC 2019";
+            string osVersion = Utility.GetVersion(osDescription);
+            Assert.IsTrue(osVersion == "4.19.28");
+        }
+    }
+}


### PR DESCRIPTION
### Summary
https://github.com/watson-developer-cloud/dotnet-standard-sdk/pull/344 inadvertently released .NET SDK v3.0.0. This was due to a breaking change that was inadvertently [merged](https://github.com/watson-developer-cloud/dotnet-standard-sdk/pull/336) and [reverted](https://github.com/watson-developer-cloud/dotnet-standard-sdk/pull/338) but the `BREAKING CHANGE` annotation was still in the git history of the `master` branch. 

I created a `v2.x.x` branch from before #344 was merged, created a feature branch and cherry-picked `0f4678d` which was the only change to v2 of the SDK. I changed semantic release and Appveyor scripts to release and deploy on merge to the `v2.x.x` branch. This should correctly build and deploy .NET SDK `v2.16.1` to Nuget.

We will use the `v2.x.x` branch for any updates to v2 of the .NET SDK and will never merge this branch into `master`.