### PR TITLE
Removed `skip ci` from bumpversion.cfg

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 current_version = 3.0.0
-message = [skip ci] docs: Update version numbers from {current_version} -> {new_version}
+message = docs: Update version numbers from {current_version} -> {new_version}
 
 [bumpversion:file:Doxyfile]
 search = {current_version}


### PR DESCRIPTION
### Summary
Currently ci is skipped on the tagged build. This results in documentation not being generated for the tagged build. This pull request removes `skip ci` from bumpversion.cfg so documentation is generated. 