### PR TITLE
Update deploy step to correct discovery v2 path

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -255,7 +255,7 @@ test_script:
 
         dotnet pack .\src\IBM.Watson.Discovery.v1\IBM.Watson.Discovery.v1.csproj --configuration Release
 
-        dotnet pack .\src\IBM.Watson.Discovery.v1\IBM.Watson.Discovery.v2.csproj --configuration Release
+        dotnet pack .\src\IBM.Watson.Discovery.v2\IBM.Watson.Discovery.v2.csproj --configuration Release
 
         dotnet pack .\src\IBM.Watson.LanguageTranslator.v3\IBM.Watson.LanguageTranslator.v3.csproj --configuration Release
 


### PR DESCRIPTION
### Summary
Discovery v2 was deployed manually to Nuget because of an error in the csproj path. This PR corrects the path so we don't run into this issue for next release.