### PR TITLE
Restore dependency version

### DIFF
--- a/test/Assistant.v1.IntegrationTests/IBM.Watson.Assistant.v1.IntegrationTests.csproj
+++ b/test/Assistant.v1.IntegrationTests/IBM.Watson.Assistant.v1.IntegrationTests.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/Assistant.v1.UnitTests/IBM.Watson.Assistant.v1.UnitTests.csproj
+++ b/test/Assistant.v1.UnitTests/IBM.Watson.Assistant.v1.UnitTests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/Assistant.v2.IntegrationTests/IBM.Watson.Assistant.v2.IntegrationTests.csproj
+++ b/test/Assistant.v2.IntegrationTests/IBM.Watson.Assistant.v2.IntegrationTests.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/Assistant.v2.UnitTests/IBM.Watson.Assistant.v2.UnitTests.csproj
+++ b/test/Assistant.v2.UnitTests/IBM.Watson.Assistant.v2.UnitTests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/CompareComply.v1.IntegrationTests/IBM.Watson.CompareComply.v1.IntegrationTests.csproj
+++ b/test/CompareComply.v1.IntegrationTests/IBM.Watson.CompareComply.v1.IntegrationTests.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/CompareComply.v1.UnitTests/IBM.Watson.CompareComply.v1.UnitTests.csproj
+++ b/test/CompareComply.v1.UnitTests/IBM.Watson.CompareComply.v1.UnitTests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/Discovery.v1.IntegrationTests/IBM.Watson.Discovery.v1.IntegrationTests.csproj
+++ b/test/Discovery.v1.IntegrationTests/IBM.Watson.Discovery.v1.IntegrationTests.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/Discovery.v1.UnitTests/IBM.Watson.Discovery.v1.UnitTests.csproj
+++ b/test/Discovery.v1.UnitTests/IBM.Watson.Discovery.v1.UnitTests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/Discovery.v2.IntegrationTests/IBM.Watson.Discovery.v2.IntegrationTests.csproj
+++ b/test/Discovery.v2.IntegrationTests/IBM.Watson.Discovery.v2.IntegrationTests.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/Discovery.v2.UnitTests/IBM.Watson.Discovery.v2.UnitTests.csproj
+++ b/test/Discovery.v2.UnitTests/IBM.Watson.Discovery.v2.UnitTests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/IBM.Watson.IntegrationTests/IBM.Watson.IntegrationTests.csproj
+++ b/test/IBM.Watson.IntegrationTests/IBM.Watson.IntegrationTests.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/LanguageTranslator.v3.IntegrationTests/IBM.Watson.LanguageTranslator.v3.IntegrationTests.csproj
+++ b/test/LanguageTranslator.v3.IntegrationTests/IBM.Watson.LanguageTranslator.v3.IntegrationTests.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/LanguageTranslator.v3.UnitTests/IBM.Watson.LanguageTranslator.v3.UnitTests.csproj
+++ b/test/LanguageTranslator.v3.UnitTests/IBM.Watson.LanguageTranslator.v3.UnitTests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/NaturalLanguageClassifier.v1.IntegrationTests/IBM.Watson.NaturalLanguageClassifier.v1.IntegrationTests.csproj
+++ b/test/NaturalLanguageClassifier.v1.IntegrationTests/IBM.Watson.NaturalLanguageClassifier.v1.IntegrationTests.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/NaturalLanguageClassifier.v1.UnitTests/IBM.Watson.NaturalLanguageClassifier.v1.UnitTests.csproj
+++ b/test/NaturalLanguageClassifier.v1.UnitTests/IBM.Watson.NaturalLanguageClassifier.v1.UnitTests.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/NaturalLanguageUnderstanding.v1.IntegrationTests/IBM.Watson.NaturalLanguageUnderstanding.v1.IntegrationTests.csproj
+++ b/test/NaturalLanguageUnderstanding.v1.IntegrationTests/IBM.Watson.NaturalLanguageUnderstanding.v1.IntegrationTests.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/NaturalLanguageUnderstanding.v1.UnitTests/IBM.Watson.NaturalLanguageUnderstanding.v1.UnitTests.csproj
+++ b/test/NaturalLanguageUnderstanding.v1.UnitTests/IBM.Watson.NaturalLanguageUnderstanding.v1.UnitTests.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/PersonalityInsights.v3.IntegrationTests/IBM.Watson.PersonalityInsights.v3.IntegrationTests.csproj
+++ b/test/PersonalityInsights.v3.IntegrationTests/IBM.Watson.PersonalityInsights.v3.IntegrationTests.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/PersonalityInsights.v3.UnitTests/IBM.Watson.PersonalityInsights.v3.UnitTests.csproj
+++ b/test/PersonalityInsights.v3.UnitTests/IBM.Watson.PersonalityInsights.v3.UnitTests.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/SpeechToText.v1.IntegrationTests/IBM.Watson.SpeechToText.v1.IntegrationTests.csproj
+++ b/test/SpeechToText.v1.IntegrationTests/IBM.Watson.SpeechToText.v1.IntegrationTests.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/SpeechToText.v1.UnitTests/IBM.Watson.SpeechToText.v1.UnitTests.csproj
+++ b/test/SpeechToText.v1.UnitTests/IBM.Watson.SpeechToText.v1.UnitTests.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/TextToSpeech.v1.IntegrationTests/IBM.Watson.TextToSpeech.v1.IntegrationTests.csproj
+++ b/test/TextToSpeech.v1.IntegrationTests/IBM.Watson.TextToSpeech.v1.IntegrationTests.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/TextToSpeech.v1.UnitTests/IBM.Watson.TextToSpeech.v1.UnitTests.csproj
+++ b/test/TextToSpeech.v1.UnitTests/IBM.Watson.TextToSpeech.v1.UnitTests.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/ToneAnalyzer.v3.IntegrationTests/IBM.Watson.ToneAnalyzer.v3.IntegrationTests.csproj
+++ b/test/ToneAnalyzer.v3.IntegrationTests/IBM.Watson.ToneAnalyzer.v3.IntegrationTests.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/ToneAnalyzer.v3.UnitTests/IBM.Watson.ToneAnalyzer.v3.UnitTests.csproj
+++ b/test/ToneAnalyzer.v3.UnitTests/IBM.Watson.ToneAnalyzer.v3.UnitTests.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/VisualRecognition.v3.IntegrationTests/IBM.Watson.VisualRecognition.v3.IntegrationTests.csproj
+++ b/test/VisualRecognition.v3.IntegrationTests/IBM.Watson.VisualRecognition.v3.IntegrationTests.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="OpenCover" Version="4.7.922" />
     <PackageReference Include="coveralls.net" Version="0.7.0" />
     <PackageReference Include="ReportGenerator" Version="4.1.5" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
   </ItemGroup>
   
 </Project>

--- a/test/VisualRecognition.v3.UnitTests/IBM.Watson.VisualRecognition.v3.UnitTests.csproj
+++ b/test/VisualRecognition.v3.UnitTests/IBM.Watson.VisualRecognition.v3.UnitTests.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />

--- a/test/VisualRecognition.v4.IntegrationTests/IBM.Watson.VisualRecognition.v4.IntegrationTests.csproj
+++ b/test/VisualRecognition.v4.IntegrationTests/IBM.Watson.VisualRecognition.v4.IntegrationTests.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="OpenCover" Version="4.7.922" />
     <PackageReference Include="coveralls.net" Version="0.7.0" />
     <PackageReference Include="ReportGenerator" Version="4.1.5" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
   </ItemGroup>
   
 </Project>

--- a/test/VisualRecognition.v4.UnitTests/IBM.Watson.VisualRecognition.v4.UnitTests.csproj
+++ b/test/VisualRecognition.v4.UnitTests/IBM.Watson.VisualRecognition.v4.UnitTests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />


### PR DESCRIPTION
### Summary
The dependency version for NSubstitute was inadvertently updated via bumpversion causing an error in ci build. This pull request restores the dependency to the correct version.