### PR TITLE
Enterprise proxy support

### DIFF
--- a/src/IBM.Watson.Assistant.v1/IBM.Watson.Assistant.v1.csproj
+++ b/src/IBM.Watson.Assistant.v1/IBM.Watson.Assistant.v1.csproj
@@ -34,8 +34,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
-        <PackageReference Include="IBM.Watson.Common" Version="5.0.1" />
+        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
+        <PackageReference Include="IBM.Watson.Common" Version="5.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="JsonSubTypes" Version="1.6.0" />
     </ItemGroup>

--- a/src/IBM.Watson.Assistant.v1/Test/Unit/IBM.Watson.Assistant.v1.UnitTests.csproj
+++ b/src/IBM.Watson.Assistant.v1/Test/Unit/IBM.Watson.Assistant.v1.UnitTests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />

--- a/src/IBM.Watson.Assistant.v2/Examples/IBM.Watson.Assistant.v2.Examples.csproj
+++ b/src/IBM.Watson.Assistant.v2/Examples/IBM.Watson.Assistant.v2.Examples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IBM.Watson.Assistant.v2/IBM.Watson.Assistant.v2.csproj
+++ b/src/IBM.Watson.Assistant.v2/IBM.Watson.Assistant.v2.csproj
@@ -34,8 +34,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
-        <PackageReference Include="IBM.Watson.Common" Version="5.0.1" />
+        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
+        <PackageReference Include="IBM.Watson.Common" Version="5.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="JsonSubTypes" Version="1.6.0" />
     </ItemGroup>

--- a/src/IBM.Watson.Assistant.v2/Test/Unit/IBM.Watson.Assistant.v2.UnitTests.csproj
+++ b/src/IBM.Watson.Assistant.v2/Test/Unit/IBM.Watson.Assistant.v2.UnitTests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />

--- a/src/IBM.Watson.Common/Common.cs
+++ b/src/IBM.Watson.Common/Common.cs
@@ -27,7 +27,7 @@ namespace IBM.Watson
         /// <summary>
         /// The SDK version.
         /// </summary>
-        public const string Version = "watson-apis-dotnet-standard-sdk-5.0.1";
+        public const string Version = "watson-apis-dotnet-standard-sdk-5.1.0";
         private static string os;
         private static string osVersion;
         private static string frameworkDescription;

--- a/src/IBM.Watson.Common/IBM.Watson.Common.csproj
+++ b/src/IBM.Watson.Common/IBM.Watson.Common.csproj
@@ -10,7 +10,7 @@
         <PackageTags>watson;cognitive;speech;vision;machine-learning;ml;ai;artificial-intelligence;.NET;.NET-Standard</PackageTags>
         <PackageIconUrl>https://watson-developer-cloud.github.io/dotnet-standard-sdk/img/Watson_Avatar_Pos_RGB.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/watson-developer-cloud/dotnet-standard-sdk</PackageProjectUrl>
-        <Version>5.0.1</Version>
+        <Version>5.1.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/IBM.Watson.CompareComply.v1/Examples/IBM.Watson.CompareComply.v1.Examples.csproj
+++ b/src/IBM.Watson.CompareComply.v1/Examples/IBM.Watson.CompareComply.v1.Examples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IBM.Watson.CompareComply.v1/IBM.Watson.CompareComply.v1.csproj
+++ b/src/IBM.Watson.CompareComply.v1/IBM.Watson.CompareComply.v1.csproj
@@ -34,8 +34,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
-        <PackageReference Include="IBM.Watson.Common" Version="5.0.1" />
+        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
+        <PackageReference Include="IBM.Watson.Common" Version="5.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="JsonSubTypes" Version="1.6.0" />
     </ItemGroup>

--- a/src/IBM.Watson.CompareComply.v1/Test/Unit/IBM.Watson.CompareComply.v1.UnitTests.csproj
+++ b/src/IBM.Watson.CompareComply.v1/Test/Unit/IBM.Watson.CompareComply.v1.UnitTests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />

--- a/src/IBM.Watson.Discovery.v1/Examples/IBM.Watson.Discovery.v1.Examples.csproj
+++ b/src/IBM.Watson.Discovery.v1/Examples/IBM.Watson.Discovery.v1.Examples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IBM.Watson.Discovery.v1/IBM.Watson.Discovery.v1.csproj
+++ b/src/IBM.Watson.Discovery.v1/IBM.Watson.Discovery.v1.csproj
@@ -34,8 +34,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
-        <PackageReference Include="IBM.Watson.Common" Version="5.0.1" />
+        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
+        <PackageReference Include="IBM.Watson.Common" Version="5.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="JsonSubTypes" Version="1.6.0" />
     </ItemGroup>

--- a/src/IBM.Watson.Discovery.v1/Test/Unit/IBM.Watson.Discovery.v1.UnitTests.csproj
+++ b/src/IBM.Watson.Discovery.v1/Test/Unit/IBM.Watson.Discovery.v1.UnitTests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />

--- a/src/IBM.Watson.Discovery.v2/DiscoveryService.cs
+++ b/src/IBM.Watson.Discovery.v2/DiscoveryService.cs
@@ -41,9 +41,9 @@ namespace IBM.Watson.Discovery.v2
         private const string defaultServiceUrl = "https://api.us-south.discovery.watson.cloud.ibm.com";
         public string Version { get; set; }
 
-        public DiscoveryService(string version) : this(version, defaultServiceName, ConfigBasedAuthenticatorFactory.GetAuthenticator(defaultServiceName)) { }
-        public DiscoveryService(string version, IAuthenticator authenticator) : this(version, defaultServiceName, authenticator) {}
-        public DiscoveryService(string version, string serviceName) : this(version, serviceName, ConfigBasedAuthenticatorFactory.GetAuthenticator(serviceName)) { }
+        public DiscoveryService(string version, WebProxy webProxy = null) : this(version, defaultServiceName, ConfigBasedAuthenticatorFactory.GetAuthenticator(defaultServiceName), webProxy) { }
+        public DiscoveryService(string version, IAuthenticator authenticator, WebProxy webProxy = null) : this(version, defaultServiceName, authenticator, webProxy) {}
+        public DiscoveryService(string version, string serviceName, WebProxy webProxy = null) : this(version, serviceName, ConfigBasedAuthenticatorFactory.GetAuthenticator(serviceName), webProxy) { }
         public DiscoveryService(IClient httpClient) : base(defaultServiceName, httpClient) { }
 
         public DiscoveryService(string version, string serviceName, IAuthenticator authenticator, WebProxy webProxy = null) : base(serviceName, authenticator, webProxy)

--- a/src/IBM.Watson.Discovery.v2/DiscoveryService.cs
+++ b/src/IBM.Watson.Discovery.v2/DiscoveryService.cs
@@ -22,6 +22,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
+using System.Net;
 using System.Text;
 using IBM.Cloud.SDK.Core.Authentication;
 using IBM.Cloud.SDK.Core.Http;
@@ -45,7 +46,7 @@ namespace IBM.Watson.Discovery.v2
         public DiscoveryService(string version, string serviceName) : this(version, serviceName, ConfigBasedAuthenticatorFactory.GetAuthenticator(serviceName)) { }
         public DiscoveryService(IClient httpClient) : base(defaultServiceName, httpClient) { }
 
-        public DiscoveryService(string version, string serviceName, IAuthenticator authenticator) : base(serviceName, authenticator)
+        public DiscoveryService(string version, string serviceName, IAuthenticator authenticator, WebProxy webProxy = null) : base(serviceName, authenticator, webProxy)
         {
             if (string.IsNullOrEmpty(version))
             {

--- a/src/IBM.Watson.Discovery.v2/Examples/IBM.Watson.Discovery.v2.Examples.csproj
+++ b/src/IBM.Watson.Discovery.v2/Examples/IBM.Watson.Discovery.v2.Examples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IBM.Watson.Discovery.v2/IBM.Watson.Discovery.v2.csproj
+++ b/src/IBM.Watson.Discovery.v2/IBM.Watson.Discovery.v2.csproj
@@ -34,8 +34,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
-        <PackageReference Include="IBM.Watson.Common" Version="5.0.1" />
+        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
+        <PackageReference Include="IBM.Watson.Common" Version="5.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="JsonSubTypes" Version="1.6.0" />
     </ItemGroup>

--- a/src/IBM.Watson.Discovery.v2/Test/Unit/DiscoveryServiceGeneratedUnitTests.cs
+++ b/src/IBM.Watson.Discovery.v2/Test/Unit/DiscoveryServiceGeneratedUnitTests.cs
@@ -55,7 +55,7 @@ namespace IBM.Watson.Discovery.v2.UnitTests
         {
             var apikey = System.Environment.GetEnvironmentVariable("DISCOVERY_APIKEY");
             System.Environment.SetEnvironmentVariable("DISCOVERY_APIKEY", "apikey");
-            DiscoveryService service = Substitute.For<DiscoveryService>("versionDate");
+            DiscoveryService service = Substitute.For<DiscoveryService>("versionDate", null);
             Assert.IsNotNull(service);
             System.Environment.SetEnvironmentVariable("DISCOVERY_APIKEY", apikey);
         }

--- a/src/IBM.Watson.Discovery.v2/Test/Unit/IBM.Watson.Discovery.v2.UnitTests.csproj
+++ b/src/IBM.Watson.Discovery.v2/Test/Unit/IBM.Watson.Discovery.v2.UnitTests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />

--- a/src/IBM.Watson.LanguageTranslator.v3/Examples/IBM.Watson.LanguageTranslator.v3.Examples.csproj
+++ b/src/IBM.Watson.LanguageTranslator.v3/Examples/IBM.Watson.LanguageTranslator.v3.Examples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IBM.Watson.LanguageTranslator.v3/IBM.Watson.LanguageTranslator.v3.csproj
+++ b/src/IBM.Watson.LanguageTranslator.v3/IBM.Watson.LanguageTranslator.v3.csproj
@@ -34,8 +34,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
-        <PackageReference Include="IBM.Watson.Common" Version="5.0.1" />
+        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
+        <PackageReference Include="IBM.Watson.Common" Version="5.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="JsonSubTypes" Version="1.6.0" />
     </ItemGroup>

--- a/src/IBM.Watson.LanguageTranslator.v3/Test/Unit/IBM.Watson.LanguageTranslator.v3.UnitTests.csproj
+++ b/src/IBM.Watson.LanguageTranslator.v3/Test/Unit/IBM.Watson.LanguageTranslator.v3.UnitTests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />

--- a/src/IBM.Watson.NaturalLanguageClassifier.v1/Examples/IBM.Watson.NLC.v1.Examples.csproj
+++ b/src/IBM.Watson.NaturalLanguageClassifier.v1/Examples/IBM.Watson.NLC.v1.Examples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IBM.Watson.NaturalLanguageClassifier.v1/IBM.Watson.NaturalLanguageClassifier.v1.csproj
+++ b/src/IBM.Watson.NaturalLanguageClassifier.v1/IBM.Watson.NaturalLanguageClassifier.v1.csproj
@@ -34,8 +34,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
-        <PackageReference Include="IBM.Watson.Common" Version="5.0.1" />
+        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
+        <PackageReference Include="IBM.Watson.Common" Version="5.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="JsonSubTypes" Version="1.6.0" />
     </ItemGroup>

--- a/src/IBM.Watson.NaturalLanguageClassifier.v1/Test/Unit/IBM.Watson.NaturalLanguageClassifier.v1.UnitTests.csproj
+++ b/src/IBM.Watson.NaturalLanguageClassifier.v1/Test/Unit/IBM.Watson.NaturalLanguageClassifier.v1.UnitTests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />

--- a/src/IBM.Watson.NaturalLanguageUnderstanding.v1/Examples/IBM.Watson.NLU.v1.Examples.csproj
+++ b/src/IBM.Watson.NaturalLanguageUnderstanding.v1/Examples/IBM.Watson.NLU.v1.Examples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IBM.Watson.NaturalLanguageUnderstanding.v1/IBM.Watson.NaturalLanguageUnderstanding.v1.csproj
+++ b/src/IBM.Watson.NaturalLanguageUnderstanding.v1/IBM.Watson.NaturalLanguageUnderstanding.v1.csproj
@@ -34,8 +34,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
-        <PackageReference Include="IBM.Watson.Common" Version="5.0.1" />
+        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
+        <PackageReference Include="IBM.Watson.Common" Version="5.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="JsonSubTypes" Version="1.6.0" />
     </ItemGroup>

--- a/src/IBM.Watson.NaturalLanguageUnderstanding.v1/Test/Unit/IBM.Watson.NaturalLanguageUnderstanding.v1.UnitTests.csproj
+++ b/src/IBM.Watson.NaturalLanguageUnderstanding.v1/Test/Unit/IBM.Watson.NaturalLanguageUnderstanding.v1.UnitTests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />

--- a/src/IBM.Watson.PersonalityInsights.v3/Examples/IBM.Watson.PersonalityInsights.v3.Examples.csproj
+++ b/src/IBM.Watson.PersonalityInsights.v3/Examples/IBM.Watson.PersonalityInsights.v3.Examples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IBM.Watson.PersonalityInsights.v3/IBM.Watson.PersonalityInsights.v3.csproj
+++ b/src/IBM.Watson.PersonalityInsights.v3/IBM.Watson.PersonalityInsights.v3.csproj
@@ -34,8 +34,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
-        <PackageReference Include="IBM.Watson.Common" Version="5.0.1" />
+        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
+        <PackageReference Include="IBM.Watson.Common" Version="5.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="JsonSubTypes" Version="1.6.0" />
     </ItemGroup>

--- a/src/IBM.Watson.PersonalityInsights.v3/Test/Unit/IBM.Watson.PersonalityInsights.v3.UnitTests.csproj
+++ b/src/IBM.Watson.PersonalityInsights.v3/Test/Unit/IBM.Watson.PersonalityInsights.v3.UnitTests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />

--- a/src/IBM.Watson.SpeechToText.v1/Examples/IBM.Watson.SpeechToText.v1.Examples.csproj
+++ b/src/IBM.Watson.SpeechToText.v1/Examples/IBM.Watson.SpeechToText.v1.Examples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IBM.Watson.SpeechToText.v1/IBM.Watson.SpeechToText.v1.csproj
+++ b/src/IBM.Watson.SpeechToText.v1/IBM.Watson.SpeechToText.v1.csproj
@@ -34,9 +34,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
-        <PackageReference Include="IBM.Watson.Common" Version="5.0.1" />
+        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
+        <PackageReference Include="IBM.Watson.Common" Version="5.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-        <PackageReference Include="JsonSubTypes" Version="1.6.0" />
+        <PackageReference Include="JsonSubTypes" Version="1.8.0" />
     </ItemGroup>
 </Project>

--- a/src/IBM.Watson.SpeechToText.v1/Test/Unit/IBM.Watson.SpeechToText.v1.UnitTests.csproj
+++ b/src/IBM.Watson.SpeechToText.v1/Test/Unit/IBM.Watson.SpeechToText.v1.UnitTests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />

--- a/src/IBM.Watson.TextToSpeech.v1/Examples/IBM.Watson.TextToSpeech.v1.Examples.csproj
+++ b/src/IBM.Watson.TextToSpeech.v1/Examples/IBM.Watson.TextToSpeech.v1.Examples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IBM.Watson.TextToSpeech.v1/IBM.Watson.TextToSpeech.v1.csproj
+++ b/src/IBM.Watson.TextToSpeech.v1/IBM.Watson.TextToSpeech.v1.csproj
@@ -34,8 +34,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
-        <PackageReference Include="IBM.Watson.Common" Version="5.0.1" />
+        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
+        <PackageReference Include="IBM.Watson.Common" Version="5.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="JsonSubTypes" Version="1.6.0" />
     </ItemGroup>

--- a/src/IBM.Watson.TextToSpeech.v1/Test/Unit/IBM.Watson.TextToSpeech.v1.UnitTests.csproj
+++ b/src/IBM.Watson.TextToSpeech.v1/Test/Unit/IBM.Watson.TextToSpeech.v1.UnitTests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />

--- a/src/IBM.Watson.ToneAnalyzer.v3/Examples/IBM.Watson.ToneAnalyzer.v3.Examples.csproj
+++ b/src/IBM.Watson.ToneAnalyzer.v3/Examples/IBM.Watson.ToneAnalyzer.v3.Examples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IBM.Watson.ToneAnalyzer.v3/IBM.Watson.ToneAnalyzer.v3.csproj
+++ b/src/IBM.Watson.ToneAnalyzer.v3/IBM.Watson.ToneAnalyzer.v3.csproj
@@ -34,8 +34,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
-        <PackageReference Include="IBM.Watson.Common" Version="5.0.1" />
+        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
+        <PackageReference Include="IBM.Watson.Common" Version="5.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="JsonSubTypes" Version="1.6.0" />
     </ItemGroup>

--- a/src/IBM.Watson.ToneAnalyzer.v3/Test/Unit/IBM.Watson.ToneAnalyzer.v3.UnitTests.csproj
+++ b/src/IBM.Watson.ToneAnalyzer.v3/Test/Unit/IBM.Watson.ToneAnalyzer.v3.UnitTests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />

--- a/src/IBM.Watson.VisualRecognition.v3/Examples/IBM.Watson.VisualRecognition.v3.Examples.csproj
+++ b/src/IBM.Watson.VisualRecognition.v3/Examples/IBM.Watson.VisualRecognition.v3.Examples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IBM.Watson.VisualRecognition.v3/IBM.Watson.VisualRecognition.v3.csproj
+++ b/src/IBM.Watson.VisualRecognition.v3/IBM.Watson.VisualRecognition.v3.csproj
@@ -34,8 +34,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
-        <PackageReference Include="IBM.Watson.Common" Version="5.0.1" />
+        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
+        <PackageReference Include="IBM.Watson.Common" Version="5.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="JsonSubTypes" Version="1.6.0" />
     </ItemGroup>

--- a/src/IBM.Watson.VisualRecognition.v3/Test/Unit/IBM.Watson.VisualRecognition.v3.UnitTests.csproj
+++ b/src/IBM.Watson.VisualRecognition.v3/Test/Unit/IBM.Watson.VisualRecognition.v3.UnitTests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />

--- a/src/IBM.Watson.VisualRecognition.v4/Examples/IBM.Watson.VisualRecognition.v4.Examples.csproj
+++ b/src/IBM.Watson.VisualRecognition.v4/Examples/IBM.Watson.VisualRecognition.v4.Examples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IBM.Watson.VisualRecognition.v4/IBM.Watson.VisualRecognition.v4.csproj
+++ b/src/IBM.Watson.VisualRecognition.v4/IBM.Watson.VisualRecognition.v4.csproj
@@ -34,8 +34,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
-        <PackageReference Include="IBM.Watson.Common" Version="5.0.1" />
+        <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
+        <PackageReference Include="IBM.Watson.Common" Version="5.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="JsonSubTypes" Version="1.6.0" />
     </ItemGroup>

--- a/src/IBM.Watson.VisualRecognition.v4/Test/Unit/IBM.Watson.VisualRecognition.v4.UnitTests.csproj
+++ b/src/IBM.Watson.VisualRecognition.v4/Test/Unit/IBM.Watson.VisualRecognition.v4.UnitTests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.1.0" />
+    <PackageReference Include="IBM.Cloud.SDK.Core" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />


### PR DESCRIPTION
Support for enterprise proxy as discussed here: https://github.com/watson-developer-cloud/dotnet-standard-sdk/issues/452

Tested Inside Enterprise Proxy
Tested Outside Enterprise Proxy

Note, Only applied the parameters to Discovery V2 would need to be applied to all other services. 