### PR TITLE
ci: fix nuget push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,7 +132,7 @@ jobs:
         # I think we can publish everytime because trying to push up a duplicate will fail with already exists and cannot be modified (409)
         # However we will try a new technique and only push if semantic release created a new release
       - name: Publish to Nuget
-        if:  ${{ steps.is_new_release.outputs.IS_NEW_RELEASE == '1' }}
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         continue-on-error: true
         env:
           NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}


### PR DESCRIPTION
### Summary

run the nuget stuff regardless of what semantic release did
